### PR TITLE
feat!: Fibonacci Fourier analysis via cut-and-project Bragg peaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -11,10 +11,10 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
-LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "v0.7.3"}
+LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "v0.8.0"}
 
 [compat]
-LatticeCore = "0.7"
+LatticeCore = "0.8"
 LinearAlgebra = "1"
 Plots = "1"
 SparseArrays = "1"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![docs: dev](https://img.shields.io/badge/docs-stable-blue.svg)](https://codes.sota-shimozono.com/QuasiCrystal.jl/stable/)
 [![Julia](https://img.shields.io/badge/julia-v1.10+-9558b2.svg)](https://julialang.org)
 [![Code Style: Blue](https://img.shields.io/badge/Code%20Style-Blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
-[![codecov](https://codecov.io/gh/sotashimozono/Lattices.jl/graph/badge.svg?token=6E7VZ9MJMK)](https://codecov.io/gh/sotashimozono/Lattices.jl)
+[![codecov](https://codecov.io/gh/sotashimozono/QuasiCrystal.jl/graph/badge.svg?token=BQ44OVM37N)](https://codecov.io/gh/sotashimozono/QuasiCrystal.jl)
 [![Build Status](https://github.com/sotashimozono/QuasiCrystal.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/QuasiCrystal.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -117,6 +117,8 @@ include("core/interface.jl")
 include("core/model/fibonacci.jl")
 include("core/model/penrose.jl")
 include("core/model/ammann_beenker.jl")
+include("core/fourier/window.jl")
+include("core/fourier/fourier.jl")
 include("utils/visualization.jl")
 
 # ---- Exports ---------------------------------------------------------
@@ -135,6 +137,9 @@ export build_quasicrystal
 export get_positions, get_bonds, get_nearest_neighbors, num_bonds
 export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
+# Fourier analysis
+export IntervalWindow, window_fourier
+export hyper_reciprocal_lattice, bragg_peaks
 
 # Re-exports from LatticeCore
 export AbstractLattice

--- a/src/core/abstractquasicrystals.jl
+++ b/src/core/abstractquasicrystals.jl
@@ -53,27 +53,34 @@ struct Tile{D,T}
 end
 
 """
-    QuasicrystalData{D, T, TileType} <: LatticeCore.AbstractLattice{D, T}
+    QuasicrystalData{D, T, Topo, TileType, L} <: LatticeCore.AbstractLattice{D, T}
 
 The concrete lattice instance returned by the `generate_*` family
 of functions. Subtype of
-[`LatticeCore.AbstractLattice`](@ref LatticeCore.AbstractLattice)`{D, T}`
-so that every LatticeCore observer, trait, and test-suite helper
-works on quasicrystals as well as on periodic lattices.
+`LatticeCore.AbstractLattice{D, T}` so that every LatticeCore
+observer, trait, and test-suite helper works on quasicrystals as
+well as on periodic lattices.
+
+The `topology::Topo` field carries the topology marker singleton
+(e.g. `FibonacciLattice()`, `PenroseP3()`, `AmmannBeenker()`).
+Fourier-analysis entry points like
+[`hyper_reciprocal_lattice`](@ref) and
+[`LatticeCore.fourier_module`](@ref LatticeCore.fourier_module)
+dispatch on `topology`'s concrete type to pick the right
+projection matrices and acceptance window.
 
 # Fields
 
+- `topology::Topo` — topology marker singleton
 - `positions::Vector{SVector{D, T}}` — physical positions of every
   site
 - `tiles::Vector{TileType}` — list of tiles in the tiling (may be
   empty for 1D lattices or ungenerated tilings)
 - `generation_method::AbstractGenerationMethod` — which algorithm
   built this instance
-- `parameters::Dict{Symbol, Any}` — free-form parameter bag kept
-  for backwards compatibility with the pre-migration API
+- `parameters::Dict{Symbol, Any}` — free-form parameter bag
 - `bonds::Vector{Bond{D, T}}` — nearest-neighbour bonds, populated
-  by [`build_nearest_neighbor_bonds!`](@ref) or by generation
-  functions that know the local connectivity
+  by [`build_nearest_neighbor_bonds!`](@ref)
 - `nearest_neighbors::Vector{Vector{Int}}` — neighbour adjacency
   lists, one per site
 - `layout::AbstractSiteLayout` — LatticeCore site layout (defaults
@@ -83,8 +90,10 @@ works on quasicrystals as well as on periodic lattices.
 with `build_nearest_neighbor_bonds!(data; cutoff)` before Monte
 Carlo observers walk the graph.
 """
-struct QuasicrystalData{D,T<:AbstractFloat,TileType,L<:AbstractSiteLayout} <:
-       AbstractLattice{D,T}
+struct QuasicrystalData{
+    D,T<:AbstractFloat,Topo<:AbstractQuasicrystal{D},TileType,L<:AbstractSiteLayout
+} <: AbstractLattice{D,T}
+    topology::Topo
     positions::Vector{SVector{D,T}}
     tiles::Vector{TileType}
     generation_method::AbstractGenerationMethod
@@ -97,17 +106,18 @@ end
 # ---- Convenience constructors ---------------------------------------
 
 function QuasicrystalData{D,T}(
+    topology::Topo,
     positions::Vector{SVector{D,T}},
     tiles::Vector{TT},
     method::AbstractGenerationMethod,
     params::Dict{Symbol,Any};
     layout::AbstractSiteLayout=UniformLayout(IsingSite()),
-) where {D,T<:AbstractFloat,TT}
+) where {D,T<:AbstractFloat,Topo<:AbstractQuasicrystal{D},TT}
     n = length(positions)
     bonds = Bond{D,T}[]
     nn = [Int[] for _ in 1:n]
-    return QuasicrystalData{D,T,TT,typeof(layout)}(
-        positions, tiles, method, params, bonds, nn, layout
+    return QuasicrystalData{D,T,Topo,TT,typeof(layout)}(
+        topology, positions, tiles, method, params, bonds, nn, layout
     )
 end
 

--- a/src/core/fourier/fourier.jl
+++ b/src/core/fourier/fourier.jl
@@ -66,9 +66,7 @@ Geometry:
 `ϕ = (1 + √5)/2` is the golden ratio (`LatticeCore.ϕ` is also
 re-exported through QuasiCrystal).
 """
-function hyper_reciprocal_lattice(
-    ::QuasicrystalData{1,Float64,FibonacciLattice}
-)
+function hyper_reciprocal_lattice(::QuasicrystalData{1,Float64,FibonacciLattice})
     T = Float64
 
     # Host lattice is Z²; its reciprocal is 2π·Z².
@@ -112,16 +110,12 @@ bound `n_max` on the integer coordinates is chosen conservatively
 from the operator norm of `parallel_proj` so that nothing bright
 slips through unnoticed.
 """
-function bragg_peaks(
-    qc::QuasicrystalData; kmax::Real, intensity_cutoff::Real=0.0
-)
+function bragg_peaks(qc::QuasicrystalData; kmax::Real, intensity_cutoff::Real=0.0)
     return _bragg_peaks_impl(hyper_reciprocal_lattice(qc), kmax, intensity_cutoff)
 end
 
 function _bragg_peaks_impl(
-    hrl::HyperReciprocalLattice{DPhys,DHyper,DPerp,T,W},
-    kmax::Real,
-    intensity_cutoff::Real,
+    hrl::HyperReciprocalLattice{DPhys,DHyper,DPerp,T,W}, kmax::Real, intensity_cutoff::Real
 ) where {DPhys,DHyper,DPerp,T,W}
     par = hrl.parallel_proj
     perp = hrl.perp_proj

--- a/src/core/fourier/fourier.jl
+++ b/src/core/fourier/fourier.jl
@@ -1,0 +1,187 @@
+"""
+Cut-and-project Fourier analysis: build a `HyperReciprocalLattice`,
+enumerate Bragg peaks up to a cutoff, and hand the result back as a
+`BraggPeakSet` that plugs into `LatticeCore.structure_factor` and
+`LatticeCore.momentum_lattice`.
+
+This file ships the generic peak-enumeration routine
+(`bragg_peaks`) plus the topology-specific constructor for
+[`FibonacciLattice`](@ref)'s `HyperReciprocalLattice`. Penrose and
+Ammann–Beenker land in follow-up PRs, once their polygonal
+acceptance windows are coded.
+"""
+
+# ---- hyper_reciprocal_lattice ---------------------------------------
+
+"""
+    hyper_reciprocal_lattice(qc::QuasicrystalData) → HyperReciprocalLattice
+
+Construct the higher-dimensional reciprocal lattice description
+for a cut-and-project quasicrystal `qc`. The returned object
+carries
+
+- `hyper_basis::SMatrix{DHyper, DHyper, T}` — basis of the hyper
+  reciprocal lattice (`(Z^DHyper)*` = `2π · Z^DHyper` for the
+  integer host lattices used by Fibonacci / Ammann–Beenker /
+  Penrose)
+- `parallel_proj::SMatrix{DPhys, DHyper, T}` — `π_∥`, the
+  projection onto physical k-space
+- `perp_proj::SMatrix{DPerp, DHyper, T}` — `π_⊥`, the projection
+  onto internal (perpendicular) space
+- `window::AcceptanceWindow` — the shape of the acceptance window
+  in `E_⊥`; its Fourier transform governs Bragg peak intensities
+
+Concrete lattice methods dispatch on the `topology` type parameter
+of `qc`.
+"""
+function hyper_reciprocal_lattice end
+
+# ---- Fibonacci: 2D host, 1D physical, 1D perp -----------------------
+
+"""
+    hyper_reciprocal_lattice(qc::QuasicrystalData{1, Float64, FibonacciLattice})
+
+Build the Fibonacci chain's cut-and-project reciprocal structure.
+
+Geometry:
+
+- **Host lattice**: `Z²`, reciprocal `2π · Z²`, so
+  `hyper_basis = 2π · I₂`.
+- **Physical line `E_∥`**: direction `(1, 1/ϕ) / ‖·‖`. The parallel
+  projection matrix is therefore
+
+    `parallel_proj = (1, 1/ϕ) / √(1 + 1/ϕ²)` (1×2).
+
+- **Perpendicular line `E_⊥`**: orthogonal direction `(-1/ϕ, 1) /
+  ‖·‖`, so
+
+    `perp_proj = (-1/ϕ, 1) / √(1 + 1/ϕ²)` (1×2).
+
+- **Acceptance window**: a symmetric 1D interval. The Fibonacci
+  generator's default choice corresponds to half-width `1/2` in
+  the `(1, 1/ϕ)` frame, scaled into the orthogonal `(e_∥, e_⊥)`
+  frame by the same `1 / √(1 + 1/ϕ²)` factor. We expose the
+  projected half-width directly.
+
+`ϕ = (1 + √5)/2` is the golden ratio (`LatticeCore.ϕ` is also
+re-exported through QuasiCrystal).
+"""
+function hyper_reciprocal_lattice(
+    ::QuasicrystalData{1,Float64,FibonacciLattice}
+)
+    T = Float64
+
+    # Host lattice is Z²; its reciprocal is 2π·Z².
+    hyper_basis = SMatrix{2,2,T}(2π, 0.0, 0.0, 2π)
+
+    # Unit vectors for the physical and perpendicular 1D subspaces.
+    norm_par = sqrt(1 + inv(ϕ)^2)
+    parallel_proj = SMatrix{1,2,T}(1 / norm_par, inv(ϕ) / norm_par)
+    perp_proj = SMatrix{1,2,T}(-inv(ϕ) / norm_par, 1 / norm_par)
+
+    # Acceptance window in the perpendicular subspace. The default
+    # projection builder (`generate_fibonacci_projection`) accepts
+    # points inside a unit-width strip in the (1, 1/ϕ) frame, which
+    # becomes a 1 / √(1+1/ϕ²) half-width = 1 / (2·norm_par) on
+    # E_⊥ after the orthonormalisation above.
+    window = IntervalWindow(T(1 / (2 * norm_par)))
+
+    return HyperReciprocalLattice{1,2,1,T,typeof(window)}(
+        hyper_basis, parallel_proj, perp_proj, window
+    )
+end
+
+# ---- Bragg peak enumeration -----------------------------------------
+
+"""
+    bragg_peaks(qc::QuasicrystalData;
+                kmax::Real,
+                intensity_cutoff::Real = 0.0) → BraggPeakSet
+
+Enumerate the finite set of Bragg peaks of a cut-and-project
+quasicrystal `qc` whose projected physical momentum has
+`‖k‖ ≤ kmax` and whose intensity `|Ŵ(g_⊥)|²` exceeds
+`intensity_cutoff`. Returns a `BraggPeakSet{DPhys, DHyper, T}`
+that inherits from `LatticeCore.AbstractMomentumLattice` and is
+therefore directly usable as a momentum lattice for
+`LatticeCore.structure_factor` and the MC observer stack.
+
+The enumeration walks every integer point in the hyper reciprocal
+lattice whose parallel projection is inside the `kmax` ball. The
+bound `n_max` on the integer coordinates is chosen conservatively
+from the operator norm of `parallel_proj` so that nothing bright
+slips through unnoticed.
+"""
+function bragg_peaks(
+    qc::QuasicrystalData; kmax::Real, intensity_cutoff::Real=0.0
+)
+    return _bragg_peaks_impl(hyper_reciprocal_lattice(qc), kmax, intensity_cutoff)
+end
+
+function _bragg_peaks_impl(
+    hrl::HyperReciprocalLattice{DPhys,DHyper,DPerp,T,W},
+    kmax::Real,
+    intensity_cutoff::Real,
+) where {DPhys,DHyper,DPerp,T,W}
+    par = hrl.parallel_proj
+    perp = hrl.perp_proj
+    A = hrl.hyper_basis
+
+    # Bound the enumeration box. The worst-case contribution to
+    # ‖k_∥‖ from a hyper index `n` with `|nᵢ| ≤ n_max` is
+    # `opnorm(par · A) * n_max * √DHyper`. Invert for n_max.
+    par_A = par * A
+    row_norms = [sqrt(sum(abs2, par_A[i, :])) for i in 1:DPhys]
+    bound = maximum(row_norms) * sqrt(DHyper)
+    n_max = bound > 0 ? ceil(Int, T(kmax) / bound) + 1 : 1
+
+    peaks = SVector{DPhys,T}[]
+    intensities = T[]
+    hyper_indices = NTuple{DHyper,Int}[]
+
+    for idx in Iterators.product(ntuple(_ -> (-n_max):n_max, DHyper)...)
+        idx_int = SVector{DHyper,Int}(idx)
+        # Zero hyper index ⇒ trivial Γ peak; keep it so users see a
+        # non-empty result for "ferromagnet on a quasicrystal".
+        g_hyper = A * SVector{DHyper,T}(T.(Tuple(idx_int)))
+        k_par = par * g_hyper
+        # StaticArrays returns SVector for matrix-vector multiply.
+        k_perp = perp * g_hyper
+
+        # Radius filter in physical k-space.
+        kpar_norm = sqrt(sum(abs2, k_par))
+        kpar_norm > T(kmax) && continue
+
+        # Window Fourier transform at the perpendicular momentum.
+        amp = window_fourier(hrl.window, k_perp)
+        I = T(abs2(amp))
+
+        I < T(intensity_cutoff) && continue
+
+        push!(peaks, SVector{DPhys,T}(k_par))
+        push!(intensities, I)
+        push!(hyper_indices, Tuple(idx_int))
+    end
+
+    return BraggPeakSet{DPhys,DHyper,T}(peaks, intensities, hyper_indices)
+end
+
+# ---- fourier_module dispatch ----------------------------------------
+
+"""
+    LatticeCore.fourier_module(qc::QuasicrystalData; kmax, intensity_cutoff) → BraggPeakSet
+
+QuasiCrystal-side override of the generic
+[`LatticeCore.fourier_module`](@ref LatticeCore.fourier_module)
+entry point. Calls [`bragg_peaks`](@ref) with the requested cutoff
+and returns a `BraggPeakSet`.
+
+Currently implemented for `FibonacciLattice` only. Passing a
+Penrose / Ammann–Beenker lattice raises a `MethodError` on
+`hyper_reciprocal_lattice`.
+"""
+function LatticeCore.fourier_module(
+    qc::QuasicrystalData; kmax::Real=20.0, intensity_cutoff::Real=0.0
+)
+    return bragg_peaks(qc; kmax=kmax, intensity_cutoff=intensity_cutoff)
+end

--- a/src/core/fourier/window.jl
+++ b/src/core/fourier/window.jl
@@ -1,0 +1,69 @@
+"""
+Acceptance windows and their Fourier transforms.
+
+A cut-and-project quasicrystal is defined by a higher-dimensional
+host lattice, a projection onto physical (`E_∥`) and perpendicular
+(`E_⊥`) subspaces, and an **acceptance window** `W ⊂ E_⊥`. The
+brightness of a Bragg peak at the projected reciprocal lattice
+vector `g_∥ = π_∥(g)` is
+
+    I(g) ∝ |Ŵ(g_⊥)|²
+
+where `g_⊥ = π_⊥(g)` and `Ŵ` is the Fourier transform of the
+window evaluated at the perpendicular-space momentum.
+
+This file defines the concrete `AcceptanceWindow` subtypes that
+`QuasiCrystal` ships, together with their analytic Fourier
+transforms. `AcceptanceWindow` itself is an abstract type living
+in `LatticeCore` (exported via QuasiCrystal's `using LatticeCore`);
+individual quasicrystals attach the window they need to their
+`HyperReciprocalLattice`.
+"""
+
+# ---- IntervalWindow -------------------------------------------------
+
+"""
+    IntervalWindow{T}(half_width::T)
+
+1D interval acceptance window `[-half_width, +half_width]`. Used
+by the Fibonacci chain (host lattice `Z²`, perpendicular space `R`).
+Its Fourier transform is a scaled sinc:
+
+```math
+\\hat{W}(q) \\;=\\; \\int_{-a}^{a} e^{-i q x}\\, dx
+         \\;=\\; \\frac{2 \\sin(q a)}{q},
+\\qquad a \\equiv \\text{half\\_width}.
+```
+
+At `q = 0` we evaluate the limit `2a` directly to avoid a division
+by zero.
+"""
+struct IntervalWindow{T<:AbstractFloat} <: AcceptanceWindow
+    half_width::T
+end
+
+"""
+    window_fourier(w::AcceptanceWindow, q) → T
+
+Evaluate `Ŵ(q)` — the Fourier transform of the acceptance window
+at perpendicular-space momentum `q`. Returns a real number (the
+scaled window integrals used here are all real because the windows
+are centred on the origin and symmetric).
+"""
+function window_fourier end
+
+function window_fourier(w::IntervalWindow{T}, q::Real) where {T}
+    a = w.half_width
+    qa = T(q) * a
+    if isapprox(qa, zero(T); atol=1e-12)
+        return 2 * a
+    end
+    return 2 * sin(qa) / T(q)
+end
+
+# Allow passing an `SVector{1}` — this makes the Fibonacci generator
+# code simpler because the perpendicular projection is naturally a
+# one-component SVector even though the window is scalar.
+function window_fourier(w::IntervalWindow{T}, q::SVector{1,<:Real}) where {T}
+    return window_fourier(w, q[1])
+end

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -67,7 +67,7 @@ function generate_ammann_beenker_projection(
         :n_vertices => length(positions),
         :symmetry => 8,
     )
-    return QuasicrystalData{2,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{2,Float64}(AmmannBeenker(), positions, tiles, method, params)
 end
 
 """
@@ -124,7 +124,7 @@ function generate_ammann_beenker_substitution(
         :n_vertices => length(positions),
         :symmetry => 8,
     )
-    return QuasicrystalData{2,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{2,Float64}(AmmannBeenker(), positions, tiles, method, params)
 end
 
 """

--- a/src/core/model/fibonacci.jl
+++ b/src/core/model/fibonacci.jl
@@ -59,7 +59,7 @@ function generate_fibonacci_projection(
     params = Dict{Symbol,Any}(
         :n_points => length(positions), :slope => slope, :method_name => "projection"
     )
-    return QuasicrystalData{1,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{1,Float64}(FibonacciLattice(), positions, tiles, method, params)
 end
 
 """
@@ -108,7 +108,7 @@ function generate_fibonacci_substitution(
         :S_spacing => S_spacing,
         :method_name => "substitution",
     )
-    return QuasicrystalData{1,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{1,Float64}(FibonacciLattice(), positions, tiles, method, params)
 end
 
 """

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -72,7 +72,7 @@ function generate_penrose_projection(
         :window_size => window_size,
         :n_vertices => length(positions),
     )
-    return QuasicrystalData{2,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{2,Float64}(PenroseP3(), positions, tiles, method, params)
 end
 
 """
@@ -126,7 +126,7 @@ function generate_penrose_substitution(
         :n_tiles => length(tiles),
         :n_vertices => length(positions),
     )
-    return QuasicrystalData{2,Float64}(positions, tiles, method, params)
+    return QuasicrystalData{2,Float64}(PenroseP3(), positions, tiles, method, params)
 end
 
 """

--- a/test/model/test_fourier_fibonacci.jl
+++ b/test/model/test_fourier_fibonacci.jl
@@ -1,0 +1,125 @@
+@testset "Fibonacci Fourier analysis" begin
+    @testset "IntervalWindow Fourier transform" begin
+        w = IntervalWindow(0.5)
+
+        # q = 0 gives the total integral 2 * half_width.
+        @test window_fourier(w, 0.0) ≈ 1.0
+        @test window_fourier(w, SVector(0.0)) ≈ 1.0
+
+        # Symmetric in q.
+        @test window_fourier(w, 3.0) ≈ window_fourier(w, -3.0)
+
+        # Matches the analytic formula 2 sin(qa) / q.
+        for q in (0.3, 1.1, 2.7, 5.4)
+            expected = 2 * sin(q * 0.5) / q
+            @test isapprox(window_fourier(w, q), expected; atol=1e-12)
+        end
+    end
+
+    @testset "hyper_reciprocal_lattice for Fibonacci" begin
+        qc = generate_fibonacci_projection(20)
+        hrl = hyper_reciprocal_lattice(qc)
+
+        # Parameter signature: (DPhys=1, DHyper=2, DPerp=1, T=Float64, W=IntervalWindow)
+        @test hrl isa HyperReciprocalLattice{1,2,1,Float64,<:IntervalWindow}
+
+        # Hyper reciprocal basis of Z² is 2π * I₂.
+        @test hrl.hyper_basis ≈ SMatrix{2,2}(2π, 0.0, 0.0, 2π)
+
+        # parallel_proj and perp_proj are orthogonal unit 1×2 rows.
+        par = hrl.parallel_proj
+        perp = hrl.perp_proj
+        @test size(par) == (1, 2)
+        @test size(perp) == (1, 2)
+        @test sum(abs2, par) ≈ 1.0 atol = 1e-10
+        @test sum(abs2, perp) ≈ 1.0 atol = 1e-10
+        @test abs(sum(par .* perp)) < 1e-10   # orthogonal
+    end
+
+    @testset "bragg_peaks returns a BraggPeakSet subtype of AbstractMomentumLattice" begin
+        qc = generate_fibonacci_projection(20)
+        peaks = bragg_peaks(qc; kmax=20.0)
+
+        @test peaks isa BraggPeakSet{1,2,Float64}
+        @test peaks isa AbstractMomentumLattice{1,Float64}
+        @test num_k_points(peaks) > 0
+
+        # Γ (hyper index (0, 0)) is always present — amplitude = 2 * half_width
+        γ_idx = findfirst(==((0, 0)), peaks.hyper_indices)
+        @test γ_idx !== nothing
+        @test peaks.peaks[γ_idx] ≈ SVector(0.0)
+
+        # Intensities are non-negative.
+        @test all(I -> I >= -1e-12, peaks.intensities)
+
+        # Γ has the largest intensity.
+        γ_I = peaks.intensities[γ_idx]
+        @test γ_I == maximum(peaks.intensities)
+    end
+
+    @testset "dominant peaks cluster around golden-ratio momenta" begin
+        # The (1, 1) and (1, 0) hyper indices are among the brightest
+        # Bragg peaks of the Fibonacci chain; at kmax = 20 they must
+        # both be present and both non-trivial.
+        qc = generate_fibonacci_projection(20)
+        peaks = bragg_peaks(qc; kmax=20.0)
+
+        indices = Set(peaks.hyper_indices)
+        @test (1, 1) in indices
+        @test (1, 0) in indices
+        @test (0, 1) in indices
+        @test (-1, 0) in indices
+        @test (0, -1) in indices
+
+        # All of these should have positive intensity (they are not
+        # filtered out by the default cutoff).
+        for hi in [(1, 1), (1, 0), (0, 1), (-1, 0), (0, -1)]
+            i = findfirst(==(hi), peaks.hyper_indices)
+            @test peaks.intensities[i] > 0
+        end
+    end
+
+    @testset "intensity_cutoff filters small peaks" begin
+        qc = generate_fibonacci_projection(20)
+        all_peaks = bragg_peaks(qc; kmax=20.0, intensity_cutoff=0.0)
+        bright_peaks = bragg_peaks(qc; kmax=20.0, intensity_cutoff=0.01)
+
+        @test num_k_points(bright_peaks) <= num_k_points(all_peaks)
+        @test all(I >= 0.01 for I in bright_peaks.intensities)
+    end
+
+    @testset "fourier_module dispatch via trait" begin
+        qc = generate_fibonacci_projection(15)
+
+        # The momentum_lattice helper dispatches on reciprocal_support,
+        # which for a QuasicrystalData is HasFourierModule(). It
+        # should route through fourier_module(qc) -> bragg_peaks(qc)
+        # with the default cutoff.
+        @test reciprocal_support(qc) isa HasFourierModule
+
+        ml = momentum_lattice(qc)
+        @test ml isa BraggPeakSet
+        @test num_k_points(ml) > 0
+
+        # Direct call with an explicit cutoff also works.
+        ml_custom = fourier_module(qc; kmax=15.0)
+        @test ml_custom isa BraggPeakSet
+    end
+
+    @testset "BraggPeakSet composes with structure_factor" begin
+        qc = generate_fibonacci_projection(20)
+        peaks = bragg_peaks(qc; kmax=10.0)
+
+        # Run structure_factor on a trivial (all-1) state. The
+        # ferromagnetic structure factor at k = 0 should be N.
+        state = ones(Int8, num_sites(qc))
+        S0 = structure_factor(qc, state, SVector(0.0))
+        @test S0 ≈ Float64(num_sites(qc)) atol = 1e-10
+
+        # And iterating structure_factor over the whole BraggPeakSet
+        # returns one real value per peak.
+        Sks = structure_factor(qc, state, peaks)
+        @test Sks isa Vector{Float64}
+        @test length(Sks) == num_k_points(peaks)
+    end
+end


### PR DESCRIPTION
## Description

First end-to-end cut-and-project Fourier analysis in `QuasiCrystal.jl`. A 1D Fibonacci chain can now return a `BraggPeakSet` of its Bragg peaks through `LatticeCore.fourier_module(qc)`, and the result plugs straight into `LatticeCore.structure_factor` and the MC observer stack through the `AbstractMomentumLattice` interface.

Penrose and Ammann–Beenker will land in follow-up PRs once their polygonal acceptance windows are coded (the `hyper_reciprocal_lattice` path falls through with `MethodError` until then).

Fixed: implements the Fibonacci track of the 05 momentum-space roadmap.

## Type of Change

- [x] ✨ Feature (`enhancement`) — **breaking struct change**
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Breaking change: topology field on QuasicrystalData

`QuasicrystalData{D, T, TileType, L}` becomes `QuasicrystalData{D, T, Topo, TileType, L}` with a new `topology::Topo` field. `Topo` is a singleton subtype of `AbstractQuasicrystal{D}` carrying the topology marker (`FibonacciLattice`, `PenroseP3`, `AmmannBeenker`).

Fourier-analysis dispatch needs this: picking the right projection matrices and window is a topology-specific decision, and making it a **type parameter** rather than a runtime field lets the method table specialise on the specific quasicrystal family without a runtime `isa` ladder.

All three `generate_*_projection` / `generate_*_substitution` functions are updated to pass their topology marker through. Tests inside QuasiCrystal only touch `QuasicrystalData` via these generators, so no test-side surgery was needed.

## Proposed changes

**`src/core/fourier/window.jl`**
- `IntervalWindow{T}(half_width)` — 1D interval acceptance window.
- Generic `window_fourier(w, q)` function, plus the analytic `IntervalWindow` method: `2 sin(qa) / q` with the `q = 0` limit handled explicitly.
- `SVector{1}` overload for the Fibonacci enumeration code path.

**`src/core/fourier/fourier.jl`**
- `hyper_reciprocal_lattice(qc::QuasicrystalData)` — generic entry point. Concrete method for `QuasicrystalData{1, Float64, FibonacciLattice}` builds `hyper_basis = 2π · I₂`, `parallel_proj = (1, 1/ϕ) / √(1 + 1/ϕ²)`, `perp_proj = (-1/ϕ, 1) / √(1 + 1/ϕ²)`, and an `IntervalWindow` matching the Fibonacci generator's unit-width acceptance strip.
- `bragg_peaks(qc; kmax, intensity_cutoff = 0.0)` — generic enumeration. Walks every integer hyper index `n ∈ Z^DHyper` whose parallel projection sits inside the `kmax` ball, computes `|window_fourier(window, n_perp)|²`, and emits a `BraggPeakSet{DPhys, DHyper, T}`. The bound on the enumeration box is derived from the operator norm of `parallel_proj * hyper_basis` so nothing bright is missed.
- `LatticeCore.fourier_module(qc::QuasicrystalData; kmax, intensity_cutoff)` — LatticeCore entry-point specialisation. Thin wrapper over `bragg_peaks`. Plugs `QuasicrystalData` into `LatticeCore.momentum_lattice` via the `HasFourierModule()` trait.

**Exports added**: `IntervalWindow`, `window_fourier`, `hyper_reciprocal_lattice`, `bragg_peaks`.

## Tests — `test/model/test_fourier_fibonacci.jl`

- **`IntervalWindow` Fourier transform**: `q = 0` limit, symmetry, agreement with `2 sin(qa) / q` at several `q`.
- **`hyper_reciprocal_lattice` for Fibonacci**: type parameters, `hyper_basis ≈ 2π · I₂`, orthogonal unit `parallel_proj` / `perp_proj` rows.
- **`bragg_peaks` contract**: returns a `BraggPeakSet{1, 2, Float64} <: AbstractMomentumLattice{1, Float64}`, Γ peak is always present with maximum intensity, intensities are non-negative.
- **Dominant peaks**: `(±1, 0)`, `(0, ±1)`, and `(1, 1)` hyper indices are all found with positive intensity — the well-known bright Fibonacci peaks.
- **`intensity_cutoff`** filters small peaks correctly.
- **`momentum_lattice(qc)`** dispatches through `HasFourierModule` and returns a `BraggPeakSet`.
- **Composition with `structure_factor`**: `S(0)` on an all-ones state equals `N`; iterating `structure_factor(qc, state, peaks)` returns one real number per Bragg peak.

Full test run: **21581 / 21581 pass** (21541 pre-Fourier + 40 new).

## `Project.toml`

- `LatticeCore` pin bumped `v0.7.3 → v0.8.0` (we need the `HyperReciprocalLattice` / `BraggPeakSet` type signatures from LatticeCore PR #12).
- `[compat] LatticeCore = "0.8"`.
- Version `0.2.2 → 0.3.0` (breaking struct change).

## README

Carries forward the codecov-badge URL fix (`Lattices.jl → QuasiCrystal.jl`) that was pending as an uncommitted local change. Unrelated to Fourier, but splitting it into its own PR would be pure bureaucratic noise.

## Follow-up

- **Penrose P3**: needs a 5-pentagon acceptance window in 3D perpendicular space. Its Fourier transform is a sum over pentagon vertices via Stokes-Green. Follow-up PR.
- **Ammann–Beenker**: regular octagon in 2D perp space. Same polygon-vertex formula style. Follow-up PR.
- **`diffraction_pattern`** visualisation, probably via `LatticeCorePlotsExt`. Follow-up PR.

## check list
- [x] test駆動をしたか — 40 new tests covering window Fourier, hyper reciprocal lattice construction, Bragg peak enumeration, trait dispatch, and end-to-end composition with `structure_factor`