### PR TITLE
feat: Ammann–Beenker Fourier analysis via BoxWindow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -138,7 +138,7 @@ export get_positions, get_bonds, get_nearest_neighbors, num_bonds
 export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
 # Fourier analysis
-export IntervalWindow, window_fourier
+export IntervalWindow, BoxWindow, window_fourier
 export hyper_reciprocal_lattice, bragg_peaks
 
 # Re-exports from LatticeCore

--- a/src/core/fourier/fourier.jl
+++ b/src/core/fourier/fourier.jl
@@ -117,12 +117,7 @@ The resulting `BraggPeakSet` plugs into
 """
 function hyper_reciprocal_lattice(::QuasicrystalData{2,Float64,AmmannBeenker})
     T = Float64
-    hyper_basis = SMatrix{4,4,T}(
-        2π, 0, 0, 0,
-        0, 2π, 0, 0,
-        0, 0, 2π, 0,
-        0, 0, 0, 2π,
-    )
+    hyper_basis = SMatrix{4,4,T}(2π, 0, 0, 0, 0, 2π, 0, 0, 0, 0, 2π, 0, 0, 0, 0, 2π)
 
     θ = T(π / 4)
     c0, s0 = cos(zero(T)), sin(zero(T))
@@ -134,21 +129,11 @@ function hyper_reciprocal_lattice(::QuasicrystalData{2,Float64,AmmannBeenker})
     # Physical star (k = 1..4): angles 0, π/4, π/2, 3π/4.
     # SMatrix is column-major, so each (col_1, col_2) pair is one
     # star vector.
-    parallel_proj = SMatrix{2,4,T}(
-        c0, s0,
-        c1, s1,
-        c2, s2,
-        c3, s3,
-    )
+    parallel_proj = SMatrix{2,4,T}(c0, s0, c1, s1, c2, s2, c3, s3)
 
     # Perpendicular star: angles π/4, π/2, 3π/4, π — the shifted
     # choice the generator currently filters with.
-    perp_proj = SMatrix{2,4,T}(
-        c1, s1,
-        c2, s2,
-        c3, s3,
-        c4, s4,
-    )
+    perp_proj = SMatrix{2,4,T}(c1, s1, c2, s2, c3, s3, c4, s4)
 
     # Square acceptance window of half-width 0.5 on each perp axis,
     # matching `generate_ammann_beenker_projection`'s

--- a/src/core/fourier/fourier.jl
+++ b/src/core/fourier/fourier.jl
@@ -89,6 +89,77 @@ function hyper_reciprocal_lattice(::QuasicrystalData{1,Float64,FibonacciLattice}
     )
 end
 
+# ---- Ammann–Beenker: 4D host, 2D physical, 2D perp ------------------
+
+"""
+    hyper_reciprocal_lattice(qc::QuasicrystalData{2, Float64, AmmannBeenker})
+
+Build the Ammann–Beenker cut-and-project reciprocal structure.
+
+Geometry (matching [`generate_ammann_beenker_projection`](@ref)):
+
+- **Host lattice**: `Z⁴`, so `hyper_basis = 2π · I₄`.
+- **Physical plane `E_∥`**: the four host basis vectors `eₖ`
+  (k = 1..4) project to the star vectors
+  `(cos((k-1)π/4), sin((k-1)π/4))`, giving a 2×4
+  `parallel_proj` whose columns are those star vectors.
+- **Perpendicular plane `E_⊥`**: shifted star vectors with angles
+  `(k-1)π/4 + π/4`. (Matches the generator's current construction
+  — note this is not the canonical Galois-conjugate embedding, but
+  it is the one that is consistent with the points actually
+  produced by the generator.)
+- **Acceptance window**: a square `|y₁|, |y₂| ≤ ½`, modelled as a
+  [`BoxWindow{2}`](@ref).
+
+The resulting `BraggPeakSet` plugs into
+`LatticeCore.momentum_lattice` and composes with
+`structure_factor` just like the Fibonacci version.
+"""
+function hyper_reciprocal_lattice(::QuasicrystalData{2,Float64,AmmannBeenker})
+    T = Float64
+    hyper_basis = SMatrix{4,4,T}(
+        2π, 0, 0, 0,
+        0, 2π, 0, 0,
+        0, 0, 2π, 0,
+        0, 0, 0, 2π,
+    )
+
+    θ = T(π / 4)
+    c0, s0 = cos(zero(T)), sin(zero(T))
+    c1, s1 = cos(θ), sin(θ)
+    c2, s2 = cos(2θ), sin(2θ)
+    c3, s3 = cos(3θ), sin(3θ)
+    c4, s4 = cos(4θ), sin(4θ)
+
+    # Physical star (k = 1..4): angles 0, π/4, π/2, 3π/4.
+    # SMatrix is column-major, so each (col_1, col_2) pair is one
+    # star vector.
+    parallel_proj = SMatrix{2,4,T}(
+        c0, s0,
+        c1, s1,
+        c2, s2,
+        c3, s3,
+    )
+
+    # Perpendicular star: angles π/4, π/2, 3π/4, π — the shifted
+    # choice the generator currently filters with.
+    perp_proj = SMatrix{2,4,T}(
+        c1, s1,
+        c2, s2,
+        c3, s3,
+        c4, s4,
+    )
+
+    # Square acceptance window of half-width 0.5 on each perp axis,
+    # matching `generate_ammann_beenker_projection`'s
+    # `all(abs.(pos_perp) .<= 0.5)` filter.
+    window = BoxWindow(SVector{2,T}(0.5, 0.5))
+
+    return HyperReciprocalLattice{2,4,2,T,typeof(window)}(
+        hyper_basis, parallel_proj, perp_proj, window
+    )
+end
+
 # ---- Bragg peak enumeration -----------------------------------------
 
 """

--- a/src/core/fourier/window.jl
+++ b/src/core/fourier/window.jl
@@ -67,3 +67,41 @@ end
 function window_fourier(w::IntervalWindow{T}, q::SVector{1,<:Real}) where {T}
     return window_fourier(w, q[1])
 end
+
+# ---- BoxWindow ------------------------------------------------------
+
+"""
+    BoxWindow{DPerp, T}(half_widths::SVector{DPerp, T})
+
+Axis-aligned hyper-rectangular acceptance window
+`∏ᵢ [-half_widthsᵢ, +half_widthsᵢ]` in `DPerp`-dimensional
+perpendicular space. Used by the Ammann–Beenker point-set generator
+(host `Z⁴`, perpendicular space `R²`, square window).
+
+Its Fourier transform is a product of 1D sincs:
+
+```math
+\\hat{W}(q) \\;=\\; \\prod_{i=1}^{D_\\perp} \\frac{2 \\sin(q_i a_i)}{q_i},
+\\qquad a_i \\equiv \\text{half\\_widths}_i.
+```
+"""
+struct BoxWindow{DPerp,T<:AbstractFloat} <: AcceptanceWindow
+    half_widths::SVector{DPerp,T}
+end
+
+function window_fourier(
+    w::BoxWindow{DPerp,T}, q::SVector{DPerp,<:Real}
+) where {DPerp,T}
+    result = one(T)
+    for i in 1:DPerp
+        a = w.half_widths[i]
+        qi = T(q[i])
+        qa = qi * a
+        if isapprox(qa, zero(T); atol=1e-12)
+            result *= 2 * a
+        else
+            result *= 2 * sin(qa) / qi
+        end
+    end
+    return result
+end

--- a/src/core/fourier/window.jl
+++ b/src/core/fourier/window.jl
@@ -89,9 +89,7 @@ struct BoxWindow{DPerp,T<:AbstractFloat} <: AcceptanceWindow
     half_widths::SVector{DPerp,T}
 end
 
-function window_fourier(
-    w::BoxWindow{DPerp,T}, q::SVector{DPerp,<:Real}
-) where {DPerp,T}
+function window_fourier(w::BoxWindow{DPerp,T}, q::SVector{DPerp,<:Real}) where {DPerp,T}
     result = one(T)
     for i in 1:DPerp
         a = w.half_widths[i]

--- a/test/model/test_fourier_ammann_beenker.jl
+++ b/test/model/test_fourier_ammann_beenker.jl
@@ -1,0 +1,130 @@
+@testset "Ammann–Beenker Fourier analysis" begin
+    @testset "BoxWindow Fourier transform" begin
+        w = BoxWindow(SVector(0.5, 0.5))
+
+        # q = 0 → total area = ∏ 2·aᵢ = 1.0
+        @test window_fourier(w, SVector(0.0, 0.0)) ≈ 1.0
+
+        # Separability: Ŵ(q₁,q₂) = sinc(q₁a₁)·sinc(q₂a₂) (with our
+        # 2 sin(qa)/q convention at q=0 → 2a).
+        for q1 in (0.3, 1.7, 4.1), q2 in (0.5, 2.2, 3.3)
+            expected = (2 * sin(q1 * 0.5) / q1) * (2 * sin(q2 * 0.5) / q2)
+            @test isapprox(
+                window_fourier(w, SVector(q1, q2)), expected; atol=1e-12
+            )
+        end
+
+        # One-axis limit: q₂ = 0 reduces to a 1D sinc times 2·a₂.
+        q1 = 1.3
+        expected = (2 * sin(q1 * 0.5) / q1) * 1.0
+        @test isapprox(
+            window_fourier(w, SVector(q1, 0.0)), expected; atol=1e-12
+        )
+
+        # Symmetric in both q axes.
+        @test window_fourier(w, SVector(1.1, 2.7)) ≈
+              window_fourier(w, SVector(-1.1, -2.7))
+    end
+
+    @testset "hyper_reciprocal_lattice for Ammann–Beenker" begin
+        qc = generate_ammann_beenker_projection(4.0)
+        hrl = hyper_reciprocal_lattice(qc)
+
+        @test hrl isa HyperReciprocalLattice{2,4,2,Float64,<:BoxWindow}
+
+        # Host reciprocal basis is 2π·I₄.
+        @test hrl.hyper_basis ≈ SMatrix{4,4,Float64}(2π * I)
+
+        par = hrl.parallel_proj
+        perp = hrl.perp_proj
+        @test size(par) == (2, 4)
+        @test size(perp) == (2, 4)
+
+        # Each column of parallel_proj is a unit star vector.
+        for k in 1:4
+            col = par[:, k]
+            @test isapprox(sum(abs2, col), 1.0; atol=1e-10)
+        end
+        for k in 1:4
+            col = perp[:, k]
+            @test isapprox(sum(abs2, col), 1.0; atol=1e-10)
+        end
+    end
+
+    @testset "bragg_peaks returns a BraggPeakSet" begin
+        qc = generate_ammann_beenker_projection(4.0)
+        peaks = bragg_peaks(qc; kmax=5.0, intensity_cutoff=1e-4)
+
+        @test peaks isa BraggPeakSet{2,4,Float64}
+        @test peaks isa AbstractMomentumLattice{2,Float64}
+        @test num_k_points(peaks) > 0
+
+        # Γ (hyper index (0,0,0,0)) is always present.
+        γ_idx = findfirst(==((0, 0, 0, 0)), peaks.hyper_indices)
+        @test γ_idx !== nothing
+        @test peaks.peaks[γ_idx] ≈ SVector(0.0, 0.0)
+
+        # Intensities are non-negative and Γ is the brightest.
+        @test all(I -> I >= -1e-12, peaks.intensities)
+        γ_I = peaks.intensities[γ_idx]
+        @test γ_I == maximum(peaks.intensities)
+        @test γ_I ≈ 1.0 atol = 1e-10  # (∏ 2·½)² = 1
+    end
+
+    @testset "8-fold rotation symmetry of the peak set" begin
+        # The physical star has 8-fold symmetry (squares + 45° rhombi).
+        # Bragg peaks should come in 8-fold rotated orbits when we
+        # restrict to a reasonable cutoff.
+        qc = generate_ammann_beenker_projection(4.0)
+        peaks = bragg_peaks(qc; kmax=5.0, intensity_cutoff=1e-3)
+
+        # For every peak, its 90° rotation should also appear in the
+        # set with the same intensity (up to numerical noise). Note:
+        # the current generator uses a shifted-by-π/4 perp frame so
+        # full 8-fold symmetry is not guaranteed, but the C₄
+        # sub-symmetry is, since the host Z⁴ has a canonical
+        # cyclic permutation that commutes with both projections.
+        R = SMatrix{2,2,Float64}(0, 1, -1, 0)  # 90° rotation
+        for (k, I) in zip(peaks.peaks, peaks.intensities)
+            I < 1e-3 && continue
+            rk = R * k
+            # find a peak close to rk
+            found = false
+            for (k2, I2) in zip(peaks.peaks, peaks.intensities)
+                if sum(abs2, k2 - rk) < 1e-8 && isapprox(I2, I; atol=1e-8)
+                    found = true
+                    break
+                end
+            end
+            @test found
+        end
+    end
+
+    @testset "intensity_cutoff filters small peaks" begin
+        qc = generate_ammann_beenker_projection(4.0)
+        all_peaks = bragg_peaks(qc; kmax=5.0, intensity_cutoff=0.0)
+        bright_peaks = bragg_peaks(qc; kmax=5.0, intensity_cutoff=0.05)
+
+        @test num_k_points(bright_peaks) <= num_k_points(all_peaks)
+        @test all(I >= 0.05 for I in bright_peaks.intensities)
+    end
+
+    @testset "fourier_module dispatch and structure_factor composition" begin
+        qc = generate_ammann_beenker_projection(4.0)
+        @test reciprocal_support(qc) isa HasFourierModule
+
+        ml = momentum_lattice(qc)
+        @test ml isa BraggPeakSet
+        @test num_k_points(ml) > 0
+
+        # All-ones ferromagnetic state: S(k=0) = N
+        peaks = bragg_peaks(qc; kmax=5.0, intensity_cutoff=1e-3)
+        state = ones(Int8, num_sites(qc))
+        S0 = structure_factor(qc, state, SVector(0.0, 0.0))
+        @test S0 ≈ Float64(num_sites(qc)) atol = 1e-8
+
+        Sks = structure_factor(qc, state, peaks)
+        @test Sks isa Vector{Float64}
+        @test length(Sks) == num_k_points(peaks)
+    end
+end

--- a/test/model/test_fourier_ammann_beenker.jl
+++ b/test/model/test_fourier_ammann_beenker.jl
@@ -9,21 +9,16 @@
         # 2 sin(qa)/q convention at q=0 → 2a).
         for q1 in (0.3, 1.7, 4.1), q2 in (0.5, 2.2, 3.3)
             expected = (2 * sin(q1 * 0.5) / q1) * (2 * sin(q2 * 0.5) / q2)
-            @test isapprox(
-                window_fourier(w, SVector(q1, q2)), expected; atol=1e-12
-            )
+            @test isapprox(window_fourier(w, SVector(q1, q2)), expected; atol=1e-12)
         end
 
         # One-axis limit: q₂ = 0 reduces to a 1D sinc times 2·a₂.
         q1 = 1.3
         expected = (2 * sin(q1 * 0.5) / q1) * 1.0
-        @test isapprox(
-            window_fourier(w, SVector(q1, 0.0)), expected; atol=1e-12
-        )
+        @test isapprox(window_fourier(w, SVector(q1, 0.0)), expected; atol=1e-12)
 
         # Symmetric in both q axes.
-        @test window_fourier(w, SVector(1.1, 2.7)) ≈
-              window_fourier(w, SVector(-1.1, -2.7))
+        @test window_fourier(w, SVector(1.1, 2.7)) ≈ window_fourier(w, SVector(-1.1, -2.7))
     end
 
     @testset "hyper_reciprocal_lattice for Ammann–Beenker" begin


### PR DESCRIPTION
## Summary
- Add `BoxWindow{DPerp,T}` — separable hyper-rectangular acceptance window whose Fourier transform is a product of 1D sincs
- Specialise `hyper_reciprocal_lattice` for `QuasicrystalData{2,Float64,AmmannBeenker}`: Z⁴ host, 2D physical star (angles 0, π/4, π/2, 3π/4), 2D perpendicular star matching the existing generator, and a square window of half-width ½
- The generic `bragg_peaks` enumeration and `LatticeCore.fourier_module` dispatch now cover A-B as well — returns a `BraggPeakSet{2,4,Float64}` that plugs into `momentum_lattice` and `structure_factor`
- 89 new tests in `test/model/test_fourier_ammann_beenker.jl` covering BoxWindow separability, HRL structure, Γ amplitude, C₄ symmetry orbit check, intensity_cutoff filtering, and structure_factor composition

Version: 0.3.0 → 0.3.1.

## Follow-up
- Penrose P3 (5D host, 2D physical, 3D perp) needs a pentagonal window
- Canonical A-B would use the Galois-conjugate perpendicular embedding and a regular octagonal window rather than the current shifted-star + square window. That is a larger generator change and is left as future work.
- `diffraction_pattern` visualisation via `LatticeCorePlotsExt`

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 21670/21670 passing locally