### PR TITLE
chore: bump LatticeCore pin to v0.8.1 (diffraction_pattern)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -11,7 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
-LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "v0.8.0"}
+LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "v0.8.1"}
 
 [compat]
 LatticeCore = "0.8"


### PR DESCRIPTION
## Summary
- Bump `[sources]` pin `LatticeCore v0.8.0 → v0.8.1` to pick up `diffraction_pattern(::AbstractMomentumLattice)` from `LatticeCorePlotsExt`
- No source changes in QuasiCrystal itself — the new plot method is generic over `BraggPeakSet` and lives in LatticeCore's Plots extension
- Verified end-to-end: Fibonacci, Ammann–Beenker, and Penrose P3 all render real-space (`plot_lattice(qc)`) and reciprocal-space (`diffraction_pattern(bragg_peaks(qc); log_intensity=true)`) from a single `using Plots, LatticeCore, QuasiCrystal` session

Version: 0.3.2 → 0.3.3.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full test suite
- [x] Manual 6-plot smoke script (3 quasicrystals × real + diffraction)