### PR TITLE
perf: stable dedup keys and KDTree position lookup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -13,6 +14,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 LatticeCore = "0.8"
 LinearAlgebra = "1.10"
+NearestNeighbors = "0.4"
 Plots = "1"
 SparseArrays = "1.10"
 StaticArrays = "1"

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -124,6 +124,7 @@ import LatticeCore:
 
 include("core/abstractquasicrystals.jl")
 include("core/interface.jl")
+include("core/numerics.jl")
 include("core/element_api.jl")
 include("core/model/fibonacci.jl")
 include("core/model/penrose.jl")

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -54,25 +54,46 @@ end
 function _materialise_plaquettes(data::QuasicrystalData{D,T}) where {D,T}
     out = Plaquette{D,T}[]
     isempty(data.tiles) && return out
+    pidx = _ensure_position_index!(data)
     for tile in data.tiles
-        vertex_ids = _resolve_tile_vertices(data, tile)
+        vertex_ids = _resolve_tile_vertices(data, tile, pidx)
         push!(out, Plaquette{D,T}(vertex_ids, tile.center, Symbol("tile_type_", tile.type)))
     end
     return out
 end
 
 """
-    _resolve_tile_vertices(data, tile) → Vector{Int}
+    _ensure_position_index!(data) → PositionIndex
+
+Lazily build and cache a KDTree over `data.positions` in
+`data.parameters[:position_index]`. The cache is keyed on the
+positions vector identity so it survives multiple plaquette / lookup
+calls without rebuilding.
+"""
+function _ensure_position_index!(data::QuasicrystalData{D,T}) where {D,T}
+    cached = get(data.parameters, :position_index, nothing)
+    if cached !== nothing
+        return cached::PositionIndex
+    end
+    pidx = build_position_index(data.positions)
+    data.parameters[:position_index] = pidx
+    return pidx
+end
+
+"""
+    _resolve_tile_vertices(data, tile, pidx) → Vector{Int}
 
 Map each of `tile.vertices` (a position in real space) back to its
-integer index in `data.positions` via a tolerant search. Throws if
-the tile vertex doesn't match any lattice site.
+integer index in `data.positions` via a tolerant KDTree query.
+Throws if the tile vertex doesn't match any lattice site.
 """
-function _resolve_tile_vertices(data::QuasicrystalData{D,T}, tile::Tile{D,T}) where {D,T}
+function _resolve_tile_vertices(
+    data::QuasicrystalData{D,T}, tile::Tile{D,T}, pidx::PositionIndex
+) where {D,T}
     out = Int[]
     sizehint!(out, length(tile.vertices))
     for tv in tile.vertices
-        idx = _find_position_index(data.positions, tv)
+        idx = find_position_index(pidx, tv, POSITION_TOLERANCE)
         idx == 0 && throw(
             ArgumentError(
                 "tile vertex at $(tv) does not match any site position on $(typeof(data).name.name)",
@@ -81,17 +102,6 @@ function _resolve_tile_vertices(data::QuasicrystalData{D,T}, tile::Tile{D,T}) wh
         push!(out, idx)
     end
     return out
-end
-
-function _find_position_index(
-    positions::Vector{SVector{D,T}}, target::SVector{D,T}
-) where {D,T}
-    for (i, p) in enumerate(positions)
-        if norm(p - target) < POSITION_TOLERANCE
-            return i
-        end
-    end
-    return 0
 end
 
 """

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -129,11 +129,11 @@ function generate_ammann_beenker_substitution(
     end
 
     # Convert to Tiles and deduplicate
-    tile_dict = Dict{Tuple{Int,Int},Tile{2,Float64}}()
+    tile_dict = Dict{NTuple{2,Int},Tile{2,Float64}}()
     for (i, j, w) in current_rhombi
         v1, v2, v3, v4 = w, w + star[i + 1], w + star[i + 1] + star[j + 1], w + star[j + 1]
         c = (v1 + v3) / 2
-        key = (round(Int, c[1]*1e5), round(Int, c[2]*1e5))
+        key = snap_to_grid(c, 1e-5)
 
         # Determine type: Square if |i-j| == 2, Rhombus if |i-j| == 1 or 3
         diff = mod(abs(i - j), 8)
@@ -146,15 +146,15 @@ function generate_ammann_beenker_substitution(
 
     tiles = collect(values(tile_dict))
 
-    # Collect unique vertices
-    position_set = Set{SVector{2,Float64}}()
+    # Collect unique vertices via stable grid snap
+    pos_dict = Dict{NTuple{2,Int},SVector{2,Float64}}()
     for tile in tiles
         for v in tile.vertices
-            rv = SVector(round(v[1]; digits=8), round(v[2]; digits=8))
-            push!(position_set, rv)
+            k = snap_to_grid(v, 1e-5)
+            get!(pos_dict, k, v)
         end
     end
-    positions = collect(position_set)
+    positions = collect(values(pos_dict))
 
     params = Dict{Symbol,Any}(
         :generations => generations,

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -143,7 +143,7 @@ function generate_penrose_substitution(
     end
 
     # Convert to Tiles and deduplicate
-    tile_dict = Dict{Tuple{Int,Int},Tile{2,Float64}}()
+    tile_dict = Dict{NTuple{2,Int},Tile{2,Float64}}()
     star_vectors = star
     for (i, j, w) in current_rhombi
         v1 = w
@@ -151,10 +151,10 @@ function generate_penrose_substitution(
         v3 = w + star_vectors[i + 1] + star_vectors[j + 1]
         v4 = w + star_vectors[j + 1]
 
-        # Canonical key for deduplication: sorted vertices
-        # Or just use the center since it's a rhombus tiling
+        # Canonical key for deduplication: snap centre to a fixed grid
+        # (stable hash key under floating-point round-off).
         center = (v1 + v3) / 2
-        key = (round(Int, center[1]*1e5), round(Int, center[2]*1e5))
+        key = snap_to_grid(center, 1e-5)
 
         # Determine type: Fat if |i-j| == 1 or 4, Thin if |i-j| == 2 or 3
         diff = mod(abs(i - j), 5)
@@ -167,16 +167,15 @@ function generate_penrose_substitution(
 
     tiles = collect(values(tile_dict))
 
-    # Collect unique vertices
-    position_set = Set{SVector{2,Float64}}()
+    # Collect unique vertices via stable grid snap
+    pos_dict = Dict{NTuple{2,Int},SVector{2,Float64}}()
     for tile in tiles
         for v in tile.vertices
-            # Round for set stable
-            rv = SVector(round(v[1]; digits=8), round(v[2]; digits=8))
-            push!(position_set, rv)
+            k = snap_to_grid(v, 1e-5)
+            get!(pos_dict, k, v)
         end
     end
-    positions = collect(position_set)
+    positions = collect(values(pos_dict))
 
     params = Dict{Symbol,Any}(
         :generations => generations,

--- a/src/core/numerics.jl
+++ b/src/core/numerics.jl
@@ -1,0 +1,97 @@
+"""
+    numerics.jl
+
+Shared numerical utilities for stable floating-point dedup and lookup
+in the substitution / projection pipelines.
+
+The two routines here are used by the tile generators (Penrose,
+Ammann–Beenker) and by the tile→plaquette conversion in
+`element_api.jl`.
+
+* `snap_to_grid(pos, eps)` produces a stable `NTuple{D, Int}` hash key
+  by snapping each coordinate to a multiple of `eps`. Replaces ad-hoc
+  `round(Int, c[i] * 1e5)` patterns that were sensitive to drift in
+  the last digits.
+* `PositionIndex` wraps a `KDTree` (from NearestNeighbors.jl) over the
+  unique-vertex list so that the tile→plaquette conversion can do
+  O(log N) tolerant lookups instead of the previous O(N) linear scan.
+"""
+
+using NearestNeighbors
+
+# ---- snap_to_grid -----------------------------------------------------
+
+"""
+    snap_to_grid(pos::SVector{D,T}, eps::Real) -> NTuple{D, Int}
+
+Snap each component of `pos` to the nearest multiple of `eps` and
+return the resulting integer tuple. Used as a stable hash key for
+deduplicating tile centres / vertices that should be equal up to
+floating-point round-off.
+
+`eps` should be small relative to the minimum spacing of distinct
+sites but comfortably larger than the accumulated round-off in the
+substitution recursion. The defaults in callers use `1e-5` (matches
+the legacy `round(Int, c*1e5)` resolution).
+"""
+@inline function snap_to_grid(pos::SVector{D,T}, eps::Real) where {D,T}
+    inv_eps = inv(T(eps))
+    return ntuple(i -> round(Int, pos[i] * inv_eps), D)
+end
+
+@inline snap_to_grid(pos::SVector{D,T}) where {D,T} = snap_to_grid(pos, T(1e-5))
+
+# ---- PositionIndex ---------------------------------------------------
+
+"""
+    PositionIndex{D,T}
+
+KDTree-backed accelerator for tolerant lookup of a position in a
+`Vector{SVector{D,T}}`. Build once via `build_position_index` and
+query with `find_position_index`.
+"""
+struct PositionIndex{D,T,Tree}
+    tree::Tree
+    npts::Int
+end
+
+"""
+    build_position_index(positions::Vector{SVector{D,T}}) -> PositionIndex
+
+Construct a KDTree over `positions`. Each query is O(log N).
+"""
+function build_position_index(positions::Vector{SVector{D,T}}) where {D,T}
+    if isempty(positions)
+        # KDTree requires at least one point; return a sentinel
+        return PositionIndex{D,T,Nothing}(nothing, 0)
+    end
+    # NearestNeighbors accepts a D×N matrix; build one explicitly.
+    N = length(positions)
+    data = Matrix{T}(undef, D, N)
+    @inbounds for j in 1:N
+        for k in 1:D
+            data[k, j] = positions[j][k]
+        end
+    end
+    tree = KDTree(data)
+    return PositionIndex{D,T,typeof(tree)}(tree, length(positions))
+end
+
+"""
+    find_position_index(idx::PositionIndex, target, tol) -> Int
+
+Return the 1-based index of the closest point to `target` if its
+distance is `< tol`, else `0`.
+"""
+function find_position_index(
+    idx::PositionIndex{D,T,Nothing}, target::SVector{D,T}, tol::Real
+) where {D,T}
+    return 0
+end
+
+function find_position_index(
+    idx::PositionIndex{D,T}, target::SVector{D,T}, tol::Real
+) where {D,T}
+    i, d = nn(idx.tree, target)
+    return d < tol ? i : 0
+end


### PR DESCRIPTION
## Summary
- Add `src/core/numerics.jl` with `snap_to_grid` (stable integer hash key for floating-point positions) and a `PositionIndex` KDTree wrapper.
- Penrose and Ammann-Beenker tile generators now use `snap_to_grid` for tile-centre dedup and unique-vertex collection, replacing ad-hoc `round(Int, c*1e5)` / `round(...; digits=8)` patterns sensitive to round-off drift.
- `_resolve_tile_vertices` in `element_api.jl` now queries a lazily-built KDTree cached on `data.parameters[:position_index]`, turning the previous O(N) linear scan into an O(log N) lookup.
- Add `NearestNeighbors` 0.4 dependency; bump version 0.3.1 -> 0.4.0.

Closes #38
Closes #39

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` -> 21704 / 21704 pass
- [ ] Spot-check large-generation Penrose / Ammann-Beenker plaquette construction is faster end-to-end