### PR TITLE
refactor!: semantic TileType hierarchy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -122,6 +122,7 @@ import LatticeCore:
 
 # ---- QuasiCrystal source files ---------------------------------------
 
+include("core/tile_types.jl")
 include("core/abstractquasicrystals.jl")
 include("core/interface.jl")
 include("core/numerics.jl")
@@ -141,6 +142,7 @@ export ProjectionMethod, SubstitutionMethod
 export AbstractSubstitutionAlgorithm,
     DefaultSubstitution, RobinsonTriangleInflation, DirectTileInflation
 export QuasicrystalData, Tile
+export TileType, FatRhombus, ThinRhombus, Square, RhombusAB, tile_type_symbol
 export vertex_angles, vertex_configuration
 export GOLDEN_RATIO, ϕ
 export FibonacciLattice, PenroseP3, AmmannBeenker

--- a/src/core/abstractquasicrystals.jl
+++ b/src/core/abstractquasicrystals.jl
@@ -63,12 +63,17 @@ SubstitutionMethod() = SubstitutionMethod(DefaultSubstitution())
     Tile{D, T}
 
 A single tile in a quasicrystalline tiling. Carries the vertices of
-the tile, an integer type id (e.g. fat vs thin rhombus), and the
-tile centre.
+the tile, a semantic [`TileType`](@ref) tag (e.g. [`FatRhombus`](@ref)
+vs [`ThinRhombus`](@ref)), and the tile centre.
+
+!!! note "Breaking change (v0.5)"
+    `type::Int` was replaced by `type::TileType`. Migrate `1/2`
+    integer tags to the geometry-specific singletons defined in
+    `src/core/tile_types.jl`.
 """
 struct Tile{D,T}
     vertices::Vector{SVector{D,T}}
-    type::Int
+    type::TileType
     center::SVector{D,T}
 end
 

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -27,8 +27,9 @@ pipeline, so the search always succeeds.
 
 Return the quasicrystal's plaquette list, derived from `data.tiles`
 on first access and cached in `data.parameters[:plaquettes]`. The
-plaquette type tag is `Symbol("tile_type_\$n")` where `n` is the
-integer `Tile.type` — downstream code that needs a richer tag can
+plaquette type tag is the semantic [`tile_type_symbol`](@ref) of the
+tile's [`TileType`](@ref) — e.g. `:fat_rhombus`, `:thin_rhombus`,
+`:square`, `:rhombus`. Downstream code that needs a richer tag can
 override the conversion after construction.
 """
 function LatticeCore.plaquettes(data::QuasicrystalData{D,T}) where {D,T}
@@ -57,7 +58,7 @@ function _materialise_plaquettes(data::QuasicrystalData{D,T}) where {D,T}
     pidx = _ensure_position_index!(data)
     for tile in data.tiles
         vertex_ids = _resolve_tile_vertices(data, tile, pidx)
-        push!(out, Plaquette{D,T}(vertex_ids, tile.center, Symbol("tile_type_", tile.type)))
+        push!(out, Plaquette{D,T}(vertex_ids, tile.center, tile_type_symbol(tile.type)))
     end
     return out
 end

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -135,9 +135,9 @@ function generate_ammann_beenker_substitution(
         c = (v1 + v3) / 2
         key = snap_to_grid(c, 1e-5)
 
-        # Determine type: Square if |i-j| == 2, Rhombus if |i-j| == 1 or 3
+        # Determine type: Square if |i-j| == 2 or 6, Rhombus otherwise.
         diff = mod(abs(i - j), 8)
-        type = (diff == 2 || diff == 6) ? 1 : 2 # type 1 is Square, 2 is Rhombus
+        type = (diff == 2 || diff == 6) ? Square() : RhombusAB()
 
         if !haskey(tile_dict, key)
             tile_dict[key] = Tile{2,Float64}([v1, v2, v3, v4], type, c)
@@ -220,7 +220,7 @@ function inflate_ammann_beenker_tiles(tiles::Vector{Tile{2,Float64}})
         c = (v1 + v3) / 2
         key = (round(Int, c[1]*1e5), round(Int, c[2]*1e5))
         diff = mod(abs(i - j), 8)
-        type = (diff == 2 || diff == 6) ? 1 : 2
+        type = (diff == 2 || diff == 6) ? Square() : RhombusAB()
         if !haskey(tile_dict, key)
             tile_dict[key] = Tile{2,Float64}([v1, v2, v3, v4], type, c)
         end

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -158,7 +158,7 @@ function generate_penrose_substitution(
 
         # Determine type: Fat if |i-j| == 1 or 4, Thin if |i-j| == 2 or 3
         diff = mod(abs(i - j), 5)
-        type = (diff == 1 || diff == 4) ? 1 : 2
+        type = (diff == 1 || diff == 4) ? FatRhombus() : ThinRhombus()
 
         if !haskey(tile_dict, key)
             tile_dict[key] = Tile{2,Float64}([v1, v2, v3, v4], type, center)
@@ -261,7 +261,7 @@ function inflate_penrose_tiles(
         c = (v1 + v3) / 2
         key = (round(Int, c[1]*1e5), round(Int, c[2]*1e5))
         diff = mod(abs(i - j), 5)
-        type = (diff == 1 || diff == 4) ? 1 : 2
+        type = (diff == 1 || diff == 4) ? FatRhombus() : ThinRhombus()
         if !haskey(tile_dict, key)
             tile_dict[key] = Tile{2,Float64}([v1, v2, v3, v4], type, c)
         end

--- a/src/core/tile_types.jl
+++ b/src/core/tile_types.jl
@@ -1,0 +1,50 @@
+"""
+Semantic tile-type taxonomy for quasicrystalline tilings.
+
+Replaces the legacy `Tile.type::Int` (1/2) encoding with named
+singleton subtypes of [`TileType`](@ref). Each generator family has
+its own concrete tile types — Penrose P3 uses [`FatRhombus`](@ref) /
+[`ThinRhombus`](@ref); Ammann–Beenker uses [`Square`](@ref) /
+[`RhombusAB`](@ref).
+
+Use [`tile_type_symbol`](@ref) to obtain the LatticeCore plaquette
+tag, e.g. `:fat_rhombus`, `:thin_rhombus`, `:square`, `:rhombus`.
+"""
+
+"""
+    abstract type TileType end
+
+Root of the semantic tile-type hierarchy. Concrete subtypes are
+singleton structs (e.g. [`FatRhombus`](@ref)) that replace the legacy
+integer `Tile.type` field.
+"""
+abstract type TileType end
+
+# --- Penrose P3 ---------------------------------------------------
+
+"""Fat rhombus (Penrose P3, 72°/108° interior angles)."""
+struct FatRhombus <: TileType end
+
+"""Thin rhombus (Penrose P3, 36°/144° interior angles)."""
+struct ThinRhombus <: TileType end
+
+# --- Ammann–Beenker -----------------------------------------------
+
+"""Square tile of the Ammann–Beenker tiling."""
+struct Square <: TileType end
+
+"""45°/135° rhombus tile of the Ammann–Beenker tiling."""
+struct RhombusAB <: TileType end
+
+# --- Symbol mapping ------------------------------------------------
+
+"""
+    tile_type_symbol(t::TileType) → Symbol
+
+Return the canonical plaquette tag (`Symbol`) for a tile type, used
+when promoting a [`Tile`](@ref) into a `LatticeCore.Plaquette`.
+"""
+tile_type_symbol(::FatRhombus) = :fat_rhombus
+tile_type_symbol(::ThinRhombus) = :thin_rhombus
+tile_type_symbol(::Square) = :square
+tile_type_symbol(::RhombusAB) = :rhombus


### PR DESCRIPTION
## Summary
- Introduce `abstract type TileType end` with concrete singletons `FatRhombus`, `ThinRhombus` (Penrose P3) and `Square`, `RhombusAB` (Ammann-Beenker) in `src/core/tile_types.jl`.
- `Tile.type` is now `::TileType` instead of `::Int`. Penrose / Ammann generators construct the semantic singletons directly instead of mapping a `diff` value to `1` / `2`.
- Plaquette tags emitted by `element_api.jl` change from `:tile_type_1` / `:tile_type_2` to `:fat_rhombus`, `:thin_rhombus`, `:square`, `:rhombus` via the new `tile_type_symbol` helper.
- Project.toml: minor bump 0.4.0 to 0.5.0.

Closes #42

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (21704/21704).

## Breaking changes
- `Tile{D,T}.type` field type changed from `Int` to `TileType`. Construction sites passing `1` / `2` must switch to `FatRhombus()` / `ThinRhombus()` (Penrose) or `Square()` / `RhombusAB()` (Ammann-Beenker).
- `Plaquette` type-tag `Symbol` returned by `plaquettes(::QuasicrystalData)` changed from `:tile_type_1` / `:tile_type_2` to `:fat_rhombus` / `:thin_rhombus` / `:square` / `:rhombus`. Downstream code matching on the old symbols must be updated.