### PR TITLE
qc batch: projection perf + substitution dispatch + fourier docs (#40 #41 #45)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -140,7 +140,11 @@ include("utils/visualization.jl")
 export AbstractQuasicrystal, AbstractGenerationMethod
 export ProjectionMethod, SubstitutionMethod
 export AbstractSubstitutionAlgorithm,
-    DefaultSubstitution, RobinsonTriangleInflation, DirectTileInflation
+    DefaultSubstitution,
+    RobinsonTriangleInflation,
+    DirectTileInflation,
+    AmmannBeenkerInflation
+export inflate_tiles
 export QuasicrystalData, Tile
 export TileType, FatRhombus, ThinRhombus, Square, RhombusAB, tile_type_symbol
 export vertex_angles, vertex_configuration

--- a/src/core/abstractquasicrystals.jl
+++ b/src/core/abstractquasicrystals.jl
@@ -53,11 +53,30 @@ struct RobinsonTriangleInflation <: AbstractSubstitutionAlgorithm end
 """Subdivide tiles directly based on vertex/edge matching."""
 struct DirectTileInflation <: AbstractSubstitutionAlgorithm end
 
+"""Ammann–Beenker-specific inflation rule: `λ·eₖ = eₖ₋₁ + eₖ + eₖ₊₁`, λ = 1+√2."""
+struct AmmannBeenkerInflation <: AbstractSubstitutionAlgorithm end
+
 """Substitution / inflation generation tag."""
 struct SubstitutionMethod{A<:AbstractSubstitutionAlgorithm} <: AbstractGenerationMethod
     algorithm::A
 end
 SubstitutionMethod() = SubstitutionMethod(DefaultSubstitution())
+
+"""
+    inflate_tiles(tiles::Vector{Tile{D, T}}, alg::AbstractSubstitutionAlgorithm)
+        → Vector{Tile{D, T}}
+
+Generic single-dispatch inflation entry point: apply the algorithm
+`alg`'s substitution rule to a list of tiles and return the inflated
+tile list. Family-specific dispatch (Penrose, Ammann–Beenker, ...)
+is provided in the corresponding `model/` files.
+
+`DefaultSubstitution` always selects an algorithm that is fully
+implemented for that family. The other algorithms may raise
+`error("not implemented")` for families where their geometric rules
+have not yet been coded.
+"""
+function inflate_tiles end
 
 """
     Tile{D, T}

--- a/src/core/fourier/fourier.jl
+++ b/src/core/fourier/fourier.jl
@@ -5,10 +5,9 @@ enumerate Bragg peaks up to a cutoff, and hand the result back as a
 `LatticeCore.momentum_lattice`.
 
 This file ships the generic peak-enumeration routine
-(`bragg_peaks`) plus the topology-specific constructor for
-[`FibonacciLattice`](@ref)'s `HyperReciprocalLattice`. Penrose and
-Ammann–Beenker land in follow-up PRs, once their polygonal
-acceptance windows are coded.
+(`bragg_peaks`) plus topology-specific constructors for
+[`FibonacciLattice`](@ref), [`AmmannBeenker`](@ref), and
+[`PenroseP3`](@ref).
 """
 
 # ---- hyper_reciprocal_lattice ---------------------------------------
@@ -297,9 +296,9 @@ QuasiCrystal-side override of the generic
 entry point. Calls [`bragg_peaks`](@ref) with the requested cutoff
 and returns a `BraggPeakSet`.
 
-Currently implemented for `FibonacciLattice` only. Passing a
-Penrose / Ammann–Beenker lattice raises a `MethodError` on
-`hyper_reciprocal_lattice`.
+Implemented for `FibonacciLattice`, `AmmannBeenker`, and
+`PenroseP3`. Topologies without a `hyper_reciprocal_lattice`
+overload raise a `MethodError`.
 """
 function LatticeCore.fourier_module(
     qc::QuasicrystalData; kmax::Real=20.0, intensity_cutoff::Real=0.0

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -253,5 +253,6 @@ end
 
 # Single-dispatch on the algorithm: `AmmannBeenkerInflation` is
 # AB-specific so this overload is unambiguous.
-inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::AmmannBeenkerInflation) =
+function inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::AmmannBeenkerInflation)
     inflate_ammann_beenker_tiles(tiles, alg)
+end

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -41,23 +41,26 @@ function generate_ammann_beenker_projection(
     end
 
     window_size = 0.5
-    raw_positions = Vector{Float64}[]
     n_max = ceil(Int, radius * 1.5)
+
+    # Pre-typed SVector buffer (avoids the legacy `Vector{Float64}[]`
+    # round-trip through plain Julia vectors).
+    positions = SVector{2,Float64}[]
+    P = SMatrix{2,4,Float64}(E_par')
+    Q = SMatrix{2,4,Float64}(E_perp')
 
     for n1 in (-n_max):n_max,
         n2 in (-n_max):n_max, n3 in (-n_max):n_max,
         n4 in (-n_max):n_max
 
-        lattice_point = [float(n1), float(n2), float(n3), float(n4)]
-        pos_par = E_par' * lattice_point
+        lp = SVector{4,Float64}(float(n1), float(n2), float(n3), float(n4))
+        pos_par = P * lp
         norm(pos_par) > radius && continue
-        pos_perp = E_perp' * lattice_point
-        if all(abs.(pos_perp) .<= window_size)
-            push!(raw_positions, pos_par)
+        pos_perp = Q * lp
+        if abs(pos_perp[1]) <= window_size && abs(pos_perp[2]) <= window_size
+            push!(positions, pos_par)
         end
     end
-
-    positions = [SVector{2,Float64}(p[1], p[2]) for p in raw_positions]
     tiles = Tile{2,Float64}[]
 
     params = Dict{Symbol,Any}(
@@ -166,9 +169,12 @@ function generate_ammann_beenker_substitution(
 end
 
 """
-    inflate_ammann_beenker_tiles(tiles::Vector{Tile{2, Float64}})
+    inflate_ammann_beenker_tiles(tiles::Vector{Tile{2, Float64}}, alg=DefaultSubstitution())
 
-Inflation rule for AB: λe₁ = e₁₋₁ + e₁ + e₁₊₁ where λ = 1+√2
+Inflation rule for AB: λe₁ = e₁₋₁ + e₁ + e₁₊₁ where λ = 1+√2.
+
+`DefaultSubstitution` and [`AmmannBeenkerInflation`](@ref) are
+fully implemented; other algorithms raise `error("not implemented")`.
 """
 function inflate_ammann_beenker_tiles(tiles::Vector{Tile{2,Float64}})
     # Robust rule for AB: λe₁ = e₁₋₁ + e₁ + e₁₊₁ where λ = 1+√2
@@ -227,3 +233,25 @@ function inflate_ammann_beenker_tiles(tiles::Vector{Tile{2,Float64}})
     end
     return collect(values(tile_dict))
 end
+
+# ---- Algorithm-dispatched inflation entry points --------------------
+
+function inflate_ammann_beenker_tiles(
+    tiles::Vector{Tile{2,Float64}}, ::Union{DefaultSubstitution,AmmannBeenkerInflation}
+)
+    return inflate_ammann_beenker_tiles(tiles)
+end
+
+function inflate_ammann_beenker_tiles(
+    ::Vector{Tile{2,Float64}}, alg::AbstractSubstitutionAlgorithm
+)
+    error(
+        "$(typeof(alg)) is not yet implemented for AmmannBeenker. " *
+        "Use DefaultSubstitution() or AmmannBeenkerInflation() instead.",
+    )
+end
+
+# Single-dispatch on the algorithm: `AmmannBeenkerInflation` is
+# AB-specific so this overload is unambiguous.
+inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::AmmannBeenkerInflation) =
+    inflate_ammann_beenker_tiles(tiles, alg)

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -45,25 +45,31 @@ function generate_penrose_projection(
     end
 
     window_size = 0.5
-    raw_positions = Vector{Float64}[]
     n_max = ceil(Int, radius * 1.5)
+
+    # Pre-typed SVector buffer: avoids the intermediate `Vector{Float64}[]`
+    # and the second pass that converted each entry to `SVector{2,Float64}`.
+    positions = SVector{2,Float64}[]
+    P = SMatrix{2,5,Float64}(E_par')
+    Q = SMatrix{3,5,Float64}(E_perp')
 
     for n1 in (-n_max):n_max,
         n2 in (-n_max):n_max, n3 in (-n_max):n_max, n4 in (-n_max):n_max,
         n5 in (-n_max):n_max
 
-        lattice_point = [float(n1), float(n2), float(n3), float(n4), float(n5)]
-        pos_par = E_par' * lattice_point
-
+        lp = SVector{5,Float64}(
+            float(n1), float(n2), float(n3), float(n4), float(n5)
+        )
+        pos_par = P * lp
         norm(pos_par) > radius && continue
 
-        pos_perp = E_perp' * lattice_point
-        if all(abs.(pos_perp) .<= window_size)
-            push!(raw_positions, pos_par)
+        pos_perp = Q * lp
+        if abs(pos_perp[1]) <= window_size &&
+            abs(pos_perp[2]) <= window_size &&
+            abs(pos_perp[3]) <= window_size
+            push!(positions, pos_par)
         end
     end
-
-    positions = [SVector{2,Float64}(p[1], p[2]) for p in raw_positions]
     tiles = Tile{2,Float64}[]   # Tile construction is a future task.
 
     params = Dict{Symbol,Any}(
@@ -272,14 +278,27 @@ end
 # Keep internal helpers for backward compatibility if needed, but they are no longer used by main loop
 
 function inflate_penrose_tiles(tiles::Vector{Tile{2,Float64}}, alg::DefaultSubstitution)
+    # `DefaultSubstitution` is contractually the fastest fully-working
+    # algorithm for the family — for Penrose that is the Robinson
+    # triangle inflation route.
     inflate_penrose_tiles(tiles, RobinsonTriangleInflation())
 end
 
-# Placeholder for direct tile inflation
-function inflate_penrose_tiles(tiles::Vector{Tile{2,Float64}}, alg::DirectTileInflation)
-    # Fallback to Robinson for now
-    return inflate_penrose_tiles(tiles, RobinsonTriangleInflation())
+# `DirectTileInflation` for Penrose is a placeholder shell — the
+# direct tile-by-tile substitution rules have not been ported yet.
+# Make the unimplemented status explicit instead of silently
+# delegating to a different algorithm.
+function inflate_penrose_tiles(::Vector{Tile{2,Float64}}, ::DirectTileInflation)
+    error(
+        "DirectTileInflation is not yet implemented for PenroseP3. " *
+        "Use DefaultSubstitution() or RobinsonTriangleInflation() instead.",
+    )
 end
+
+# Single-dispatch on the algorithm: `RobinsonTriangleInflation` is
+# Penrose-specific, so this overload is unambiguous.
+inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::RobinsonTriangleInflation) =
+    inflate_penrose_tiles(tiles, alg)
 
 export vertex_angles, vertex_configuration
 

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -57,9 +57,7 @@ function generate_penrose_projection(
         n2 in (-n_max):n_max, n3 in (-n_max):n_max, n4 in (-n_max):n_max,
         n5 in (-n_max):n_max
 
-        lp = SVector{5,Float64}(
-            float(n1), float(n2), float(n3), float(n4), float(n5)
-        )
+        lp = SVector{5,Float64}(float(n1), float(n2), float(n3), float(n4), float(n5))
         pos_par = P * lp
         norm(pos_par) > radius && continue
 
@@ -297,8 +295,9 @@ end
 
 # Single-dispatch on the algorithm: `RobinsonTriangleInflation` is
 # Penrose-specific, so this overload is unambiguous.
-inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::RobinsonTriangleInflation) =
+function inflate_tiles(tiles::Vector{Tile{2,Float64}}, alg::RobinsonTriangleInflation)
     inflate_penrose_tiles(tiles, alg)
+end
 
 export vertex_angles, vertex_configuration
 

--- a/test/model/test_substitution_dispatch.jl
+++ b/test/model/test_substitution_dispatch.jl
@@ -1,0 +1,37 @@
+@testset "substitution algorithm dispatch (#41)" begin
+    # Penrose: DefaultSubstitution and RobinsonTriangleInflation are
+    # both fully wired through `inflate_tiles`; DirectTileInflation
+    # is an explicit not-implemented shell.
+    qc = generate_penrose_substitution(1)
+    tiles = qc.tiles
+    @test !isempty(tiles)
+
+    inflated_default = QuasiCrystal.inflate_penrose_tiles(tiles, DefaultSubstitution())
+    inflated_robin = QuasiCrystal.inflate_penrose_tiles(tiles, RobinsonTriangleInflation())
+    @test length(inflated_default) == length(inflated_robin)
+    @test length(inflated_robin) > length(tiles)
+
+    # Public single-dispatch API.
+    @test length(inflate_tiles(tiles, RobinsonTriangleInflation())) ==
+        length(inflated_robin)
+
+    @test_throws ErrorException QuasiCrystal.inflate_penrose_tiles(
+        tiles, DirectTileInflation()
+    )
+
+    # Ammann–Beenker: DefaultSubstitution and AmmannBeenkerInflation
+    # are fully wired; the Penrose-specific Robinson algorithm raises.
+    ab = generate_ammann_beenker_substitution(1)
+    ab_tiles = ab.tiles
+    @test !isempty(ab_tiles)
+    inflated_ab_default = QuasiCrystal.inflate_ammann_beenker_tiles(
+        ab_tiles, DefaultSubstitution()
+    )
+    @test length(inflated_ab_default) > length(ab_tiles)
+    @test length(inflate_tiles(ab_tiles, AmmannBeenkerInflation())) ==
+        length(inflated_ab_default)
+
+    @test_throws ErrorException QuasiCrystal.inflate_ammann_beenker_tiles(
+        ab_tiles, RobinsonTriangleInflation()
+    )
+end


### PR DESCRIPTION
## Summary
- #40: drop the intermediate `Vector{Float64}[]` projection buffer in the Penrose / Ammann–Beenker generators; push straight into a typed `SVector{2,Float64}[]` and promote `E_par`/`E_perp` to `SMatrix` for stack-allocated multiplies.
- #41: introduce a generic `inflate_tiles(::Vector{Tile}, ::Algorithm)` single-dispatch entry plus an `AmmannBeenkerInflation` singleton. `DefaultSubstitution` keeps its current behaviour (Penrose → Robinson, AB → built-in λ=1+√2 rule); unimplemented algorithm/family pairs now raise an explicit `error("not yet implemented ...")` instead of silently falling back to a different algorithm.
- #45: refresh `fourier.jl` header / `fourier_module` docstring to reflect that `hyper_reciprocal_lattice` + `bragg_peaks` are wired for all three families. `bragg_peaks` is already exported.
- Patch bump 0.5.0 → 0.5.1.

Closes #40
Closes #41
Closes #45

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` (21811 / 21811 pass)
- [x] New `test/model/test_substitution_dispatch.jl` covers `inflate_tiles` for both families plus the `error()` paths for unimplemented algorithm × family combos.
- [x] Existing fourier tests for Fibonacci / Ammann–Beenker / Penrose still pass.