### PR TITLE
qc batch: tolerance constants + window_shape accessor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -124,8 +124,8 @@ import LatticeCore:
 
 include("core/tile_types.jl")
 include("core/abstractquasicrystals.jl")
-include("core/interface.jl")
 include("core/numerics.jl")
+include("core/interface.jl")
 include("core/element_api.jl")
 include("core/model/fibonacci.jl")
 include("core/model/penrose.jl")
@@ -157,6 +157,8 @@ export fibonacci_sequence_length
 export build_quasicrystal
 export get_positions, get_bonds, get_nearest_neighbors, num_bonds
 export num_plaquettes, bond_type
+export window_shape
+export VERTEX_MERGE_TOL, SNAP_GRID_EPS, STAR_DIRECTION_TOL, positions_equal
 export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
 # Fourier analysis

--- a/src/core/abstractquasicrystals.jl
+++ b/src/core/abstractquasicrystals.jl
@@ -175,6 +175,40 @@ function LatticeCore.boundary(::QuasicrystalData{D}) where {D}
     LatticeBoundary(ntuple(_ -> OpenAxis(), D), NoModifier())
 end
 
+"""
+    window_shape(data::QuasicrystalData) → Symbol
+
+Return the acceptance-window shape used to generate `data`, looked up
+from `data.parameters[:window_shape]`. The shape is a finer-grained
+descriptor than the global `boundary()` trait — the latter currently
+returns `OpenAxis` on every axis for any quasicrystal because
+LatticeCore's `AbstractAxisBC` cannot yet express a non-trivial
+acceptance window in perpendicular space.
+
+The shipped generators populate `:window_shape` as follows:
+
+| Generator                             | `:window_shape` |
+|---------------------------------------|-----------------|
+| `generate_fibonacci_projection`       | `:interval_1d`  |
+| `generate_ammann_beenker_projection`  | `:box_2d`       |
+| `generate_penrose_projection`         | `:box_3d`       |
+| `generate_*_substitution`             | `:none`         |
+
+If the key is absent the function returns `:unknown`. Custom
+generators are encouraged to write their window descriptor under the
+`:window_shape` key so downstream tooling (Fourier diagnostics,
+boundary refinement, ...) can dispatch on it without parsing the
+generation method.
+
+A richer trait-based dispatch (extending
+`LatticeCore.AbstractAxisBC` to carry an explicit window) is tracked
+as a separate follow-up; this accessor is the minimal hook callers
+need today.
+"""
+function window_shape(data::QuasicrystalData)
+    return get(data.parameters, :window_shape, :unknown)::Symbol
+end
+
 LatticeCore.site_layout(data::QuasicrystalData) = data.layout
 
 function LatticeCore.size_trait(data::QuasicrystalData)

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -94,7 +94,7 @@ function _resolve_tile_vertices(
     out = Int[]
     sizehint!(out, length(tile.vertices))
     for tv in tile.vertices
-        idx = find_position_index(pidx, tv, POSITION_TOLERANCE)
+        idx = find_position_index(pidx, tv, VERTEX_MERGE_TOL)
         idx == 0 && throw(
             ArgumentError(
                 "tile vertex at $(tv) does not match any site position on $(typeof(data).name.name)",

--- a/src/core/interface.jl
+++ b/src/core/interface.jl
@@ -8,9 +8,6 @@ exported by LatticeCore and work on any `AbstractLattice`. The
 names in this file remain for legacy code that spells them out.
 """
 
-"""Position tolerance for duplicate-detection in `build_nearest_neighbor_bonds!`."""
-const POSITION_TOLERANCE = 1e-10
-
 """
     get_positions(data::QuasicrystalData) → Vector{SVector{D, T}}
 
@@ -48,7 +45,7 @@ num_bonds(data::QuasicrystalData) = length(data.bonds)
 
 Populate `data.bonds` and `data.nearest_neighbors` with all pairs
 of sites whose Euclidean distance is strictly less than `cutoff`
-and strictly greater than `POSITION_TOLERANCE`. Existing bonds are
+and strictly greater than `VERTEX_MERGE_TOL`. Existing bonds are
 cleared first. Mutates `data.bonds` and the inner vectors of
 `data.nearest_neighbors` in place.
 
@@ -71,7 +68,7 @@ function build_nearest_neighbor_bonds!(
             pos_j = data.positions[j]
             bond_vec = pos_j - pos_i
             dist = norm(bond_vec)
-            if dist < cutoff && dist > POSITION_TOLERANCE
+            if dist < cutoff && dist > VERTEX_MERGE_TOL
                 push!(data.bonds, Bond{D,T}(i, j, bond_vec, :nearest))
                 push!(data.nearest_neighbors[i], j)
                 push!(data.nearest_neighbors[j], i)

--- a/src/core/model/ammann_beenker.jl
+++ b/src/core/model/ammann_beenker.jl
@@ -67,6 +67,7 @@ function generate_ammann_beenker_projection(
         :radius => radius,
         :n_max => n_max,
         :window_size => window_size,
+        :window_shape => :box_2d,
         :n_vertices => length(positions),
         :symmetry => 8,
     )
@@ -136,7 +137,7 @@ function generate_ammann_beenker_substitution(
     for (i, j, w) in current_rhombi
         v1, v2, v3, v4 = w, w + star[i + 1], w + star[i + 1] + star[j + 1], w + star[j + 1]
         c = (v1 + v3) / 2
-        key = snap_to_grid(c, 1e-5)
+        key = snap_to_grid(c, SNAP_GRID_EPS)
 
         # Determine type: Square if |i-j| == 2 or 6, Rhombus otherwise.
         diff = mod(abs(i - j), 8)
@@ -153,7 +154,7 @@ function generate_ammann_beenker_substitution(
     pos_dict = Dict{NTuple{2,Int},SVector{2,Float64}}()
     for tile in tiles
         for v in tile.vertices
-            k = snap_to_grid(v, 1e-5)
+            k = snap_to_grid(v, SNAP_GRID_EPS)
             get!(pos_dict, k, v)
         end
     end
@@ -164,6 +165,7 @@ function generate_ammann_beenker_substitution(
         :n_tiles => length(tiles),
         :n_vertices => length(positions),
         :symmetry => 8,
+        :window_shape => :none,
     )
     return QuasicrystalData{2,Float64}(AmmannBeenker(), positions, tiles, method, params)
 end
@@ -188,10 +190,10 @@ function inflate_ammann_beenker_tiles(tiles::Vector{Tile{2,Float64}})
         e1, e2 = v[2] - v1, v[4] - v1
         i = j = -1
         for k in 0:7
-            if norm(e1 - star[k + 1]) < 1e-4
+            if norm(e1 - star[k + 1]) < STAR_DIRECTION_TOL
                 i = k
             end
-            if norm(e2 - star[k + 1]) < 1e-4
+            if norm(e2 - star[k + 1]) < STAR_DIRECTION_TOL
                 j = k
             end
         end

--- a/src/core/model/fibonacci.jl
+++ b/src/core/model/fibonacci.jl
@@ -57,7 +57,10 @@ function generate_fibonacci_projection(
     tiles = Tile{1,Float64}[]
 
     params = Dict{Symbol,Any}(
-        :n_points => length(positions), :slope => slope, :method_name => "projection"
+        :n_points => length(positions),
+        :slope => slope,
+        :method_name => "projection",
+        :window_shape => :interval_1d,
     )
     return QuasicrystalData{1,Float64}(FibonacciLattice(), positions, tiles, method, params)
 end
@@ -107,6 +110,7 @@ function generate_fibonacci_substitution(
         :L_spacing => L_spacing,
         :S_spacing => S_spacing,
         :method_name => "substitution",
+        :window_shape => :none,
     )
     return QuasicrystalData{1,Float64}(FibonacciLattice(), positions, tiles, method, params)
 end

--- a/src/core/model/penrose.jl
+++ b/src/core/model/penrose.jl
@@ -74,6 +74,7 @@ function generate_penrose_projection(
         :radius => radius,
         :n_max => n_max,
         :window_size => window_size,
+        :window_shape => :box_3d,
         :n_vertices => length(positions),
     )
     return QuasicrystalData{2,Float64}(PenroseP3(), positions, tiles, method, params)
@@ -158,7 +159,7 @@ function generate_penrose_substitution(
         # Canonical key for deduplication: snap centre to a fixed grid
         # (stable hash key under floating-point round-off).
         center = (v1 + v3) / 2
-        key = snap_to_grid(center, 1e-5)
+        key = snap_to_grid(center, SNAP_GRID_EPS)
 
         # Determine type: Fat if |i-j| == 1 or 4, Thin if |i-j| == 2 or 3
         diff = mod(abs(i - j), 5)
@@ -175,7 +176,7 @@ function generate_penrose_substitution(
     pos_dict = Dict{NTuple{2,Int},SVector{2,Float64}}()
     for tile in tiles
         for v in tile.vertices
-            k = snap_to_grid(v, 1e-5)
+            k = snap_to_grid(v, SNAP_GRID_EPS)
             get!(pos_dict, k, v)
         end
     end
@@ -185,6 +186,7 @@ function generate_penrose_substitution(
         :generations => generations,
         :n_tiles => length(tiles),
         :n_vertices => length(positions),
+        :window_shape => :none,
     )
     return QuasicrystalData{2,Float64}(PenroseP3(), positions, tiles, method, params)
 end
@@ -220,13 +222,13 @@ function inflate_penrose_tiles(
         i = -1
         j = -1
         for k in 0:4
-            if norm(e1 - star[k + 1]) < 1e-4
+            if norm(e1 - star[k + 1]) < STAR_DIRECTION_TOL
                 i = k
-            elseif norm(e1 + star[k + 1]) < 1e-4
+            elseif norm(e1 + star[k + 1]) < STAR_DIRECTION_TOL
                 # Handle mirrored/inverted tiles if necessary
                 # In P3 they are usually aligned to star
             end
-            if norm(e2 - star[k + 1]) < 1e-4
+            if norm(e2 - star[k + 1]) < STAR_DIRECTION_TOL
                 j = k
             end
         end

--- a/src/core/numerics.jl
+++ b/src/core/numerics.jl
@@ -19,6 +19,76 @@ Ammann–Beenker) and by the tile→plaquette conversion in
 
 using NearestNeighbors
 
+# ---- Tolerance constants ---------------------------------------------
+#
+# Centralised numerical tolerances for the substitution / projection
+# pipelines. Each call site that previously hardcoded a magic number
+# (`1e-10`, `1e-5`, `1e-4`) now references one of these named
+# constants so the trade-offs are documented in one place and any
+# future tightening / loosening can be done in a single edit.
+
+"""
+    VERTEX_MERGE_TOL
+
+Distance tolerance below which two real-space site / vertex positions
+are considered the same point. Used by the bond builder
+(`build_nearest_neighbor_bonds!`) to skip self-pairs and by the
+tile→plaquette KDTree lookup in `_resolve_tile_vertices`.
+
+Value: `1e-10`. This is several orders of magnitude smaller than the
+minimum inter-site spacing produced by the shipped projection /
+substitution generators (`O(1)` in the natural units of the
+construction), and comfortably larger than the round-off accumulated
+by a few generations of recursion.
+"""
+const VERTEX_MERGE_TOL = 1e-10
+
+"""
+    POSITION_TOLERANCE
+
+Legacy alias for [`VERTEX_MERGE_TOL`](@ref). Retained for
+backwards-compatibility with callers that imported the old name.
+"""
+const POSITION_TOLERANCE = VERTEX_MERGE_TOL
+
+"""
+    SNAP_GRID_EPS
+
+Resolution of the integer-tuple hash key produced by
+[`snap_to_grid`](@ref). Distinct sites produced by the substitution
+pipeline are well separated at this scale; round-off in deep
+recursion is comfortably below it.
+
+Value: `1e-5` — matches the legacy `round(Int, c * 1e5)` resolution.
+"""
+const SNAP_GRID_EPS = 1e-5
+
+"""
+    STAR_DIRECTION_TOL
+
+Tolerance for matching an inflated tile edge to one of the unit
+star vectors `e_k = (cos(2πk/n), sin(2πk/n))` in the substitution
+inflation rules (Penrose, Ammann–Beenker). Looser than
+[`VERTEX_MERGE_TOL`](@ref) because the comparison is between unit
+vectors after a long chain of multiplications by `ϕ`, not between
+sites of the lattice.
+
+Value: `1e-4`.
+"""
+const STAR_DIRECTION_TOL = 1e-4
+
+"""
+    positions_equal(a, b; tol = VERTEX_MERGE_TOL) -> Bool
+
+Tolerant equality test between two real-space positions.
+Returns `true` iff `norm(a - b) < tol`.
+"""
+@inline function positions_equal(
+    a::SVector{D,T}, b::SVector{D,T}; tol::Real=VERTEX_MERGE_TOL
+) where {D,T}
+    return norm(a - b) < tol
+end
+
 # ---- snap_to_grid -----------------------------------------------------
 
 """
@@ -39,7 +109,7 @@ the legacy `round(Int, c*1e5)` resolution).
     return ntuple(i -> round(Int, pos[i] * inv_eps), D)
 end
 
-@inline snap_to_grid(pos::SVector{D,T}) where {D,T} = snap_to_grid(pos, T(1e-5))
+@inline snap_to_grid(pos::SVector{D,T}) where {D,T} = snap_to_grid(pos, T(SNAP_GRID_EPS))
 
 # ---- PositionIndex ---------------------------------------------------
 

--- a/test/model/test_numerics_and_window.jl
+++ b/test/model/test_numerics_and_window.jl
@@ -1,0 +1,40 @@
+using QuasiCrystal, Test, StaticArrays
+
+@testset "numerics tolerance constants" begin
+    @test QuasiCrystal.VERTEX_MERGE_TOL == 1e-10
+    @test QuasiCrystal.POSITION_TOLERANCE === QuasiCrystal.VERTEX_MERGE_TOL
+    @test QuasiCrystal.SNAP_GRID_EPS == 1e-5
+    @test QuasiCrystal.STAR_DIRECTION_TOL == 1e-4
+
+    a = SVector(0.0, 0.0)
+    b = SVector(1e-12, 0.0)
+    c = SVector(0.5, 0.0)
+    @test positions_equal(a, b)
+    @test !positions_equal(a, c)
+    @test positions_equal(a, c; tol=1.0)
+end
+
+@testset "window_shape accessor" begin
+    fib_p = generate_fibonacci_projection(50)
+    @test window_shape(fib_p) === :interval_1d
+
+    fib_s = generate_fibonacci_substitution(4)
+    @test window_shape(fib_s) === :none
+
+    ab_p = generate_ammann_beenker_projection(2.0)
+    @test window_shape(ab_p) === :box_2d
+
+    ab_s = generate_ammann_beenker_substitution(2)
+    @test window_shape(ab_s) === :none
+
+    pen_p = generate_penrose_projection(2.0)
+    @test window_shape(pen_p) === :box_3d
+
+    pen_s = generate_penrose_substitution(2)
+    @test window_shape(pen_s) === :none
+
+    # Absent key falls back to :unknown.
+    pen_p.parameters[:window_shape] = :unknown
+    delete!(pen_p.parameters, :window_shape)
+    @test window_shape(pen_p) === :unknown
+end


### PR DESCRIPTION
## Summary
- Centralise tolerance magic numbers (1e-10 / 1e-5 / 1e-4) into named constants `VERTEX_MERGE_TOL`, `SNAP_GRID_EPS`, `STAR_DIRECTION_TOL` in `src/core/numerics.jl`; add `positions_equal` helper. `POSITION_TOLERANCE` retained as alias.
- Add `window_shape(::QuasicrystalData)` accessor reading `parameters[:window_shape]`; projection generators tag `:interval_1d` / `:box_2d` / `:box_3d`, substitution generators tag `:none`. Boundary trait left untouched (richer `AbstractAxisBC` extension is a separate follow-up).
- Bump version to 0.5.2.

Closes #43
Closes #44

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (21825/21825)
- [x] New `test/model/test_numerics_and_window.jl` covers tolerance constants, `positions_equal`, and `window_shape` for all six generator entry points.