### PR TITLE
test: add Aqua.jl quality checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -12,16 +12,19 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+Aqua = "0.8"
 LatticeCore = "0.8"
 LinearAlgebra = "1.10"
 NearestNeighbors = "0.4"
 Plots = "1"
 SparseArrays = "1.10"
 StaticArrays = "1"
+Test = "1.10"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ In this module, QuasiCrystals structures are available including,
 - Penrose Tile
 - Amman Beenker Lattice
 
+Package quality is checked on CI via [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl)
+(`Aqua.test_all`), covering ambiguities, unbound type parameters, undefined
+exports, stale dependencies, and Method-of-piracy.
+
 ## Features
 
 ### Unified AbstractLattice Interface

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,4 +26,10 @@ const dirs = ["model"]
             end
         end
     end
+
+    @time begin
+        aqua_path = joinpath(@__DIR__, "test_aqua.jl")
+        println("\n  Including $(aqua_path)")
+        include(aqua_path)
+    end
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,11 +4,7 @@ using QuasiCrystal
 @testset "Aqua quality checks" begin
     # Full Aqua sweep, with fine-grained skips below for known
     # cross-package method ambiguities (LatticeCore / NearestNeighbors).
-    Aqua.test_all(
-        QuasiCrystal;
-        ambiguities = false,
-        stale_deps = (; ignore = [:Plots],),
-    )
+    Aqua.test_all(QuasiCrystal; ambiguities=false, stale_deps=(; ignore=[:Plots],))
 
     # Run ambiguity check restricted to QuasiCrystal itself, so that
     # ambiguities introduced by upstream packages do not fail CI.

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,18 @@
+using Aqua
+using QuasiCrystal
+
+@testset "Aqua quality checks" begin
+    # Full Aqua sweep, with fine-grained skips below for known
+    # cross-package method ambiguities (LatticeCore / NearestNeighbors).
+    Aqua.test_all(
+        QuasiCrystal;
+        ambiguities = false,
+        stale_deps = (; ignore = [:Plots],),
+    )
+
+    # Run ambiguity check restricted to QuasiCrystal itself, so that
+    # ambiguities introduced by upstream packages do not fail CI.
+    @testset "ambiguities (QuasiCrystal-only)" begin
+        Aqua.test_ambiguities(QuasiCrystal)
+    end
+end


### PR DESCRIPTION
## Summary

- Wire `Aqua.test_all(QuasiCrystal)` into the test suite (`test/test_aqua.jl`, included from `runtests.jl`). Package-wide ambiguity check is disabled and replaced with `Aqua.test_ambiguities(QuasiCrystal)` to avoid false positives from upstream LatticeCore / NearestNeighbors ambiguities. `Plots` is added to `stale_deps.ignore` because it is loaded for visualization helpers that Aqua's static scan does not see referenced.
- `Project.toml`: register `Aqua` in `[extras]` + `[targets.test]` with `compat = "0.8"`, plus `Test = "1.10"` so Aqua's `deps_compat` check passes. Patch bump 0.5.2 -> 0.5.3.
- `README.md`: one-paragraph note describing the Aqua sweep coverage.

Closes #37

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes locally (21836 pass / 0 fail), Aqua subset: ambiguities (QuasiCrystal-only), unbound type parameters, undefined exports, project-vs-test compat, stale deps (with `Plots` ignored), compat bounds, piracy, persistent tasks.
- [ ] CI green on PR.