### PR TITLE
feat: fill LatticeCore optional API gaps on QuasicrystalData

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/abstractquasicrystals.jl
+++ b/src/core/abstractquasicrystals.jl
@@ -217,8 +217,34 @@ end
 
 LatticeCore.bonds(data::QuasicrystalData) = data.bonds
 
+"""
+    positions(data::QuasicrystalData) → Vector{SVector{D, T}}
+
+Return the dense vector of site positions backing `data`. The
+LatticeCore default builds a generator from `position(data, i)`;
+since `QuasicrystalData` already stores all positions densely we
+return the field directly, avoiding the per-call dispatch and
+allocation of the generator wrapper. Callers that mutate the
+returned vector will mutate the lattice in place — same contract as
+`get_positions`.
+"""
+LatticeCore.positions(data::QuasicrystalData) = data.positions
+
 # Quasicrystals are aperiodic by construction: they admit no
 # Bravais reciprocal lattice (they have a dense Fourier module
 # instead, which is handled by `LatticeCore.fourier_module`).
 LatticeCore.periodicity(::QuasicrystalData) = Aperiodic()
 LatticeCore.reciprocal_support(::QuasicrystalData) = HasFourierModule()
+
+"""
+    topology(data::QuasicrystalData) → TopologyTrait{:quasiperiodic}()
+
+QuasiCrystal-side override of the generic LatticeCore topology
+trait. Every `QuasicrystalData`, regardless of which generator
+family produced it (Fibonacci, Penrose, Ammann–Beenker, ...),
+shares the `:quasiperiodic` topology tag — distinct from `:square`,
+`:line`, etc. used by the periodic reference lattices. Family-level
+discrimination remains available through `data.topology` (the
+`AbstractQuasicrystal{D}` marker singleton stored on the data).
+"""
+LatticeCore.topology(::QuasicrystalData) = TopologyTrait{:quasiperiodic}()

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -132,6 +132,188 @@ function LatticeCore.element_position(data::QuasicrystalData, ::PlaquetteCenter,
     return plaquettes(data)[i].center
 end
 
+# ---- element_positions iterators (issue #32) ---------------------
+#
+# The generic LatticeCore default builds a generator from
+# `element_position(lat, e, i)` for `i in 1:num_elements(lat, e)`.
+# That works but is needlessly indirect for QuasicrystalData, which
+# already stores positions / bond endpoints / tile centres densely.
+# These specialisations return iterators that go straight to the
+# backing storage — no per-call dispatch through `element_position`.
+
+"""
+    element_positions(data::QuasicrystalData, ::VertexCenter)
+
+Iterator over site positions. Returns `data.positions` directly, so
+this is O(1) and allocation-free.
+"""
+function LatticeCore.element_positions(data::QuasicrystalData, ::VertexCenter)
+    return data.positions
+end
+
+"""
+    element_positions(data::QuasicrystalData, ::BondCenter)
+
+Iterator over bond midpoints. Each element is computed lazily from
+the corresponding `Bond` via [`bond_center`](@ref) — no intermediate
+`Vector` is materialised.
+"""
+function LatticeCore.element_positions(data::QuasicrystalData, ::BondCenter)
+    return (bond_center(data, b) for b in data.bonds)
+end
+
+"""
+    element_positions(data::QuasicrystalData, ::PlaquetteCenter)
+
+Iterator over plaquette centres. Each element is the cached
+`Plaquette.center` field.
+"""
+function LatticeCore.element_positions(data::QuasicrystalData, ::PlaquetteCenter)
+    return (p.center for p in plaquettes(data))
+end
+
+# ---- neighbor_bonds specialisation (issue #31) -------------------
+
+"""
+    neighbor_bonds(data::QuasicrystalData, i::Int)
+
+Iterator of bonds incident to site `i`. Walks `data.bonds` once and
+keeps every bond that has `i` as an endpoint, so the cost is O(B)
+where `B = length(data.bonds)`. Compared to the generic LatticeCore
+default — which rebuilds a `Bond` object on the fly from
+`neighbors(data, i)` — this returns the original stored `Bond`
+objects (preserving their `vector` and `type` fields) without the
+intermediate construction.
+"""
+function LatticeCore.neighbor_bonds(data::QuasicrystalData, i::Int)
+    return (b for b in data.bonds if b.i == i || b.j == i)
+end
+
+# ---- element_neighbors PlaquetteCenter specialisation (issue #33) -
+
+"""
+    element_neighbors(data::QuasicrystalData, ::PlaquetteCenter, i::Int)
+
+Indices of plaquettes that share at least one boundary edge with
+plaquette `i` (the dual graph). Specialises the generic LatticeCore
+implementation by indexing plaquettes by their integer vertex sets
+once instead of re-collecting on every comparison.
+"""
+function LatticeCore.element_neighbors(
+    data::QuasicrystalData, ::PlaquetteCenter, i::Int
+)
+    ps = plaquettes(data)
+    1 ≤ i ≤ length(ps) || throw(BoundsError(ps, i))
+    p = ps[i]
+    p_edges = _plaquette_edge_set(p)
+    out = Int[]
+    for k in eachindex(ps)
+        k == i && continue
+        other_edges = _plaquette_edge_set(ps[k])
+        for e in p_edges
+            if e in other_edges
+                push!(out, k)
+                break
+            end
+        end
+    end
+    return out
+end
+
+# Edge set of a plaquette as a `Set{Tuple{Int,Int}}` of unordered
+# vertex pairs (smaller index first), suitable for O(1) membership
+# tests when comparing two plaquettes.
+function _plaquette_edge_set(p::Plaquette)
+    vs = p.vertices
+    n = length(vs)
+    s = Set{Tuple{Int,Int}}()
+    for k in 1:n
+        a = vs[k]
+        b = vs[mod1(k + 1, n)]
+        push!(s, a < b ? (a, b) : (b, a))
+    end
+    return s
+end
+
+# ---- incident query (issue #36) ----------------------------------
+#
+# The generic LatticeCore implementations work but call
+# `collect(plaquettes(...))` / `collect(bonds(...))` per query. For
+# QuasicrystalData both are already dense vectors; the
+# specialisations below skip the redundant collect.
+
+# Vertex → Bond: bonds touching site i. Walks data.bonds once.
+function LatticeCore.incident(
+    data::QuasicrystalData, ::VertexCenter, ::BondCenter, i::Int
+)
+    return [k for (k, b) in enumerate(data.bonds) if b.i == i || b.j == i]
+end
+
+# Bond → Vertex: endpoints of bond i.
+function LatticeCore.incident(
+    data::QuasicrystalData, ::BondCenter, ::VertexCenter, i::Int
+)
+    b = data.bonds[i]
+    return [b.i, b.j]
+end
+
+# Vertex → Plaquette: plaquettes whose boundary contains site i.
+function LatticeCore.incident(
+    data::QuasicrystalData, ::VertexCenter, ::PlaquetteCenter, i::Int
+)
+    ps = plaquettes(data)
+    return [k for (k, p) in enumerate(ps) if i in p.vertices]
+end
+
+# Plaquette → Vertex: boundary vertices of plaquette i (cyclic order).
+function LatticeCore.incident(
+    data::QuasicrystalData, ::PlaquetteCenter, ::VertexCenter, i::Int
+)
+    return plaquettes(data)[i].vertices
+end
+
+# Bond → Plaquette: plaquettes whose boundary contains bond i.
+function LatticeCore.incident(
+    data::QuasicrystalData, ::BondCenter, ::PlaquetteCenter, i::Int
+)
+    b = data.bonds[i]
+    target = b.i < b.j ? (b.i, b.j) : (b.j, b.i)
+    ps = plaquettes(data)
+    out = Int[]
+    for (k, p) in enumerate(ps)
+        if target in _plaquette_edge_set(p)
+            push!(out, k)
+        end
+    end
+    return out
+end
+
+# Plaquette → Bond: bond indices forming the boundary of plaquette i.
+# Each boundary edge is matched against `data.bonds` by endpoint
+# pair; unmatched edges (e.g. when bonds were not yet built) are
+# skipped.
+function LatticeCore.incident(
+    data::QuasicrystalData, ::PlaquetteCenter, ::BondCenter, i::Int
+)
+    p = plaquettes(data)[i]
+    vs = p.vertices
+    n = length(vs)
+    out = Int[]
+    for kedge in 1:n
+        a = vs[kedge]
+        b = vs[mod1(kedge + 1, n)]
+        target = a < b ? (a, b) : (b, a)
+        for (kb, bb) in enumerate(data.bonds)
+            ep = bb.i < bb.j ? (bb.i, bb.j) : (bb.j, bb.i)
+            if ep == target
+                push!(out, kb)
+                break
+            end
+        end
+    end
+    return out
+end
+
 # ---- Multi-shell neighbours (distance-based) ---------------------
 
 """

--- a/src/core/element_api.jl
+++ b/src/core/element_api.jl
@@ -199,9 +199,7 @@ plaquette `i` (the dual graph). Specialises the generic LatticeCore
 implementation by indexing plaquettes by their integer vertex sets
 once instead of re-collecting on every comparison.
 """
-function LatticeCore.element_neighbors(
-    data::QuasicrystalData, ::PlaquetteCenter, i::Int
-)
+function LatticeCore.element_neighbors(data::QuasicrystalData, ::PlaquetteCenter, i::Int)
     ps = plaquettes(data)
     1 ≤ i ≤ length(ps) || throw(BoundsError(ps, i))
     p = ps[i]
@@ -243,16 +241,12 @@ end
 # specialisations below skip the redundant collect.
 
 # Vertex → Bond: bonds touching site i. Walks data.bonds once.
-function LatticeCore.incident(
-    data::QuasicrystalData, ::VertexCenter, ::BondCenter, i::Int
-)
+function LatticeCore.incident(data::QuasicrystalData, ::VertexCenter, ::BondCenter, i::Int)
     return [k for (k, b) in enumerate(data.bonds) if b.i == i || b.j == i]
 end
 
 # Bond → Vertex: endpoints of bond i.
-function LatticeCore.incident(
-    data::QuasicrystalData, ::BondCenter, ::VertexCenter, i::Int
-)
+function LatticeCore.incident(data::QuasicrystalData, ::BondCenter, ::VertexCenter, i::Int)
     b = data.bonds[i]
     return [b.i, b.j]
 end

--- a/test/model/test_api_gap_lc_impl.jl
+++ b/test/model/test_api_gap_lc_impl.jl
@@ -1,0 +1,139 @@
+using QuasiCrystal, Test
+using StaticArrays
+
+@testset "API gap: LatticeCore optional interface" begin
+    # Build a small Penrose patch (has bonds and plaquettes). The
+    # substitution generator populates `tiles`, which the
+    # `plaquettes` machinery needs; the projection generator
+    # currently does not.
+    pen = generate_penrose_substitution(2)
+    build_nearest_neighbor_bonds!(pen; cutoff=1.05)
+    @test num_bonds(pen) > 0
+    @test num_plaquettes(pen) > 0
+
+    # Also exercise a 1D Fibonacci instance — it has no plaquettes
+    # but should still respond to vertex/bond queries.
+    fib = generate_fibonacci_substitution(5)
+    build_nearest_neighbor_bonds!(fib; cutoff=GOLDEN_RATIO + 0.05)
+    @test num_bonds(fib) > 0
+
+    @testset "neighbor_bonds(lat, i) (issue #31)" begin
+        # Pick a site that has at least one neighbour bond.
+        i = findfirst(!isempty, get_nearest_neighbors(pen))
+        @test i !== nothing
+        bs = collect(neighbor_bonds(pen, i))
+        @test !isempty(bs)
+        # Every returned bond must touch site i and must come from
+        # the actual bond list (preserving the stored `:nearest` tag
+        # and unwrapped vector — not a freshly fabricated bond).
+        for b in bs
+            @test b.i == i || b.j == i
+            @test b.type === :nearest
+            @test b in get_bonds(pen)
+        end
+        # And the count must match the adjacency-list degree.
+        @test length(bs) == length(get_nearest_neighbors(pen)[i])
+
+        # 1D sanity check on Fibonacci.
+        i1 = findfirst(!isempty, get_nearest_neighbors(fib))
+        @test i1 !== nothing
+        @test all(b -> b.i == i1 || b.j == i1, neighbor_bonds(fib, i1))
+    end
+
+    @testset "element_positions iterators (issue #32)" begin
+        # VertexCenter: identical to `positions(data)`.
+        vps = collect(element_positions(pen, VertexCenter()))
+        @test vps == get_positions(pen)
+        @test length(vps) == num_sites(pen)
+
+        # BondCenter: midpoint of every stored bond.
+        bps = collect(element_positions(pen, BondCenter()))
+        @test length(bps) == num_bonds(pen)
+        for (k, b) in enumerate(get_bonds(pen))
+            @test bps[k] ≈ bond_center(pen, b)
+        end
+
+        # PlaquetteCenter: each Plaquette's `center` field.
+        pps = collect(element_positions(pen, PlaquetteCenter()))
+        @test length(pps) == num_plaquettes(pen)
+        for (k, p) in enumerate(plaquettes(pen))
+            @test pps[k] == p.center
+        end
+    end
+
+    @testset "element_neighbors PlaquetteCenter (issue #33)" begin
+        ps = plaquettes(pen)
+        # Find a plaquette index that actually has a neighbour
+        # (Penrose tilings always have some plaquette with a shared
+        # edge, so this should succeed on a non-degenerate patch).
+        ks = [k for k in 1:length(ps) if !isempty(element_neighbors(pen, PlaquetteCenter(), k))]
+        @test !isempty(ks)
+        k = first(ks)
+        nbrs = element_neighbors(pen, PlaquetteCenter(), k)
+        # Every reported neighbour must share at least one boundary
+        # edge (vertex pair) with plaquette k.
+        function _edges(p)
+            vs = p.vertices
+            n = length(vs)
+            return Set(Tuple{Int,Int}[
+                (min(vs[i], vs[mod1(i + 1, n)]), max(vs[i], vs[mod1(i + 1, n)])) for i in 1:n
+            ])
+        end
+        e_k = _edges(ps[k])
+        for j in nbrs
+            @test j != k
+            @test !isempty(intersect(e_k, _edges(ps[j])))
+        end
+    end
+
+    @testset "positions(lat) returns the backing vector (issue #34)" begin
+        # Specialisation should hand back the actual storage.
+        @test positions(pen) === pen.positions
+        @test positions(fib) === fib.positions
+        # And it must agree with `get_positions`.
+        @test positions(pen) == get_positions(pen)
+    end
+
+    @testset "topology trait :quasiperiodic (issue #35)" begin
+        @test topology(pen) === TopologyTrait{:quasiperiodic}()
+        @test topology(fib) === TopologyTrait{:quasiperiodic}()
+        ab = generate_ammann_beenker_substitution(2)
+        @test topology(ab) === TopologyTrait{:quasiperiodic}()
+    end
+
+    @testset "incident query (issue #36)" begin
+        # Pick a vertex with at least one bond.
+        v = findfirst(!isempty, get_nearest_neighbors(pen))
+        @test v !== nothing
+
+        # Vertex ↔ Bond round-trip.
+        v_bonds = incident(pen, VertexCenter(), BondCenter(), v)
+        @test !isempty(v_bonds)
+        for kb in v_bonds
+            ends = incident(pen, BondCenter(), VertexCenter(), kb)
+            @test v in ends
+            @test length(ends) == 2
+        end
+
+        # Vertex ↔ Plaquette round-trip: pick a vertex that lies on a tile.
+        v_with_p = findfirst(i -> any(p -> i in p.vertices, plaquettes(pen)), 1:num_sites(pen))
+        @test v_with_p !== nothing
+        v_plaqs = incident(pen, VertexCenter(), PlaquetteCenter(), v_with_p)
+        @test !isempty(v_plaqs)
+        for kp in v_plaqs
+            verts = incident(pen, PlaquetteCenter(), VertexCenter(), kp)
+            @test v_with_p in verts
+        end
+
+        # Bond ↔ Plaquette: pick a plaquette and verify the boundary
+        # edges resolve back to bonds (when those bonds exist).
+        ps = plaquettes(pen)
+        for kp in 1:length(ps)
+            p_bonds = incident(pen, PlaquetteCenter(), BondCenter(), kp)
+            for kb in p_bonds
+                p_back = incident(pen, BondCenter(), PlaquetteCenter(), kb)
+                @test kp in p_back
+            end
+        end
+    end
+end

--- a/test/model/test_api_gap_lc_impl.jl
+++ b/test/model/test_api_gap_lc_impl.jl
@@ -66,7 +66,10 @@ using StaticArrays
         # Find a plaquette index that actually has a neighbour
         # (Penrose tilings always have some plaquette with a shared
         # edge, so this should succeed on a non-degenerate patch).
-        ks = [k for k in 1:length(ps) if !isempty(element_neighbors(pen, PlaquetteCenter(), k))]
+        ks = [
+            k for
+            k in 1:length(ps) if !isempty(element_neighbors(pen, PlaquetteCenter(), k))
+        ]
         @test !isempty(ks)
         k = first(ks)
         nbrs = element_neighbors(pen, PlaquetteCenter(), k)
@@ -75,9 +78,12 @@ using StaticArrays
         function _edges(p)
             vs = p.vertices
             n = length(vs)
-            return Set(Tuple{Int,Int}[
-                (min(vs[i], vs[mod1(i + 1, n)]), max(vs[i], vs[mod1(i + 1, n)])) for i in 1:n
-            ])
+            return Set(
+                Tuple{Int,Int}[
+                    (min(vs[i], vs[mod1(i + 1, n)]), max(vs[i], vs[mod1(i + 1, n)])) for
+                    i in 1:n
+                ],
+            )
         end
         e_k = _edges(ps[k])
         for j in nbrs
@@ -116,7 +122,9 @@ using StaticArrays
         end
 
         # Vertex ↔ Plaquette round-trip: pick a vertex that lies on a tile.
-        v_with_p = findfirst(i -> any(p -> i in p.vertices, plaquettes(pen)), 1:num_sites(pen))
+        v_with_p = findfirst(
+            i -> any(p -> i in p.vertices, plaquettes(pen)), 1:num_sites(pen)
+        )
         @test v_with_p !== nothing
         v_plaqs = incident(pen, VertexCenter(), PlaquetteCenter(), v_with_p)
         @test !isempty(v_plaqs)


### PR DESCRIPTION
## Summary

- Specialise the LatticeCore optional interface so every QuasicrystalData (Fibonacci / Penrose / Ammann–Beenker, projection or substitution) plugs into LatticeCore's element-center and incidence helpers.
  - `neighbor_bonds(lat, i)` walks `data.bonds` once and yields the stored `Bond` objects (#31).
  - `element_positions(lat, ::VertexCenter / ::BondCenter / ::PlaquetteCenter)` returns direct iterators backed by `positions` / `bonds` / `plaquettes` (#32).
  - `element_neighbors(lat, ::PlaquetteCenter, i)` builds the dual graph by indexing each plaquette's boundary edges in a `Set` once (#33).
  - `positions(lat)` returns the dense `data.positions` field directly (#34).
  - `topology(lat)` overrides the LatticeCore default to `TopologyTrait{:quasiperiodic}()` for every quasicrystal family (#35).
  - `incident(lat, src, tgt, i)` covers all six vertex / bond / plaquette pairs without the generic `collect` round-trips (#36).
- Bumps version to 0.5.4 (patch).

Closes #31, #32, #33, #34, #35, #36.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (23616 / 23616, including Aqua quality checks).
- [x] New `test/model/test_api_gap_lc_impl.jl` exercises every API on a Penrose substitution patch and the Fibonacci substitution lattice, with explicit invariants per issue (round-trip incidence, dual-edge sharing, identity equality with the backing vector, `:quasiperiodic` trait).