### PR TITLE
Plots ext recipe: plot_acceptance_window for cut-and-project

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,15 +7,16 @@ authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
 NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
 QuasiCrystalNFFTExt = "NFFT"
+QuasiCrystalPlotsExt = "Plots"
 
 [compat]
 Aqua = "0.8"
@@ -33,8 +34,9 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "NFFT", "Random", "Test"]
+test = ["Aqua", "NFFT", "Plots", "Random", "Test"]

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -107,7 +107,7 @@ function QuasiCrystal.plot_acceptance_window(
     else
         throw(
             ArgumentError(
-                "plot_acceptance_window does not yet handle window_shape == :$(shape).",
+                "plot_acceptance_window does not yet handle window_shape == :$(shape)."
             ),
         )
     end
@@ -135,8 +135,7 @@ end
 # user supplies a custom generator that does record
 # `:window_size`, we honour it.
 function _direct_half_widths(
-    data::QuasiCrystal.QuasicrystalData,
-    hrl::LatticeCore.HyperReciprocalLattice,
+    data::QuasiCrystal.QuasicrystalData, hrl::LatticeCore.HyperReciprocalLattice
 )
     DPerp = size(hrl.perp_proj, 1)
     if haskey(data.parameters, :window_size)
@@ -162,7 +161,9 @@ _default_n_hyper(::QuasiCrystal.QuasicrystalData) = 4
 # *direct-space* integer host points (Z^DHyper), not the reciprocal
 # ones — the educational picture is "which n ∈ Z^DHyper survive the
 # perp-window filter".
-function _projected_hyper_points(perp_proj::SMatrix{DPerp,DHyper,T}, n::Int) where {DPerp,DHyper,T}
+function _projected_hyper_points(
+    perp_proj::SMatrix{DPerp,DHyper,T}, n::Int
+) where {DPerp,DHyper,T}
     pts = SVector{DPerp,Float64}[]
     sizehint!(pts, (2n + 1)^DHyper)
     ranges = ntuple(_ -> (-n):n, DHyper)
@@ -214,15 +215,17 @@ function _plot_window_interval(
 
     # Window: thick segment on y = 0 with end caps.
     Plots.plot!(
+        plt, [-half, half], [0.0, 0.0]; linewidth=4, color=:steelblue, label="window"
+    )
+    Plots.scatter!(
         plt,
         [-half, half],
         [0.0, 0.0];
-        linewidth=4,
+        marker=:vline,
+        markersize=12,
         color=:steelblue,
-        label="window",
+        label="",
     )
-    Plots.scatter!(plt, [-half, half], [0.0, 0.0]; marker=:vline, markersize=12,
-                   color=:steelblue, label="")
 
     if show_hyper_points
         pts = _projected_hyper_points(geom.perp_proj, n)
@@ -230,14 +233,23 @@ function _plot_window_interval(
         if !isempty(inside)
             xs = [p[1] for p in inside]
             ys = zeros(length(xs))
-            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=4,
-                           color=:darkorange, label="inside")
+            Plots.scatter!(
+                plt, xs, ys; marker=:circle, markersize=4, color=:darkorange, label="inside"
+            )
         end
         if !isempty(outside)
             xs = [p[1] for p in outside]
             ys = zeros(length(xs))
-            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=3,
-                           color=:gray, label="outside", alpha=0.5)
+            Plots.scatter!(
+                plt,
+                xs,
+                ys;
+                marker=:circle,
+                markersize=3,
+                color=:gray,
+                label="outside",
+                alpha=0.5,
+            )
         end
     end
 
@@ -287,14 +299,23 @@ function _plot_window_box2d(
         if !isempty(inside)
             xs = [p[1] for p in inside]
             ys = [p[2] for p in inside]
-            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=4,
-                           color=:darkorange, label="inside")
+            Plots.scatter!(
+                plt, xs, ys; marker=:circle, markersize=4, color=:darkorange, label="inside"
+            )
         end
         if !isempty(outside)
             xs = [p[1] for p in outside]
             ys = [p[2] for p in outside]
-            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=3,
-                           color=:gray, label="outside", alpha=0.5)
+            Plots.scatter!(
+                plt,
+                xs,
+                ys;
+                marker=:circle,
+                markersize=3,
+                color=:gray,
+                label="outside",
+                alpha=0.5,
+            )
         end
     end
 
@@ -320,19 +341,18 @@ function _plot_window_box3d(
     @assert length(hw) == 3
     n = n_hyper === nothing ? _default_n_hyper(data) : n_hyper
 
-    pts = show_hyper_points ? _projected_hyper_points(geom.perp_proj, n) :
+    pts = if show_hyper_points
+        _projected_hyper_points(geom.perp_proj, n)
+    else
         SVector{3,Float64}[]
+    end
     inside, outside = _split_points(pts, hw)
 
     panels = Plots.Plot[]
     for (i, j, label) in ((1, 2, "y₁ vs y₂"), (1, 3, "y₁ vs y₃"), (2, 3, "y₂ vs y₃"))
         a, b = hw[i], hw[j]
         sub = Plots.plot(;
-            xlabel="y$(i)",
-            ylabel="y$(j)",
-            aspect_ratio=:equal,
-            title=label,
-            legend=false,
+            xlabel="y$(i)", ylabel="y$(j)", aspect_ratio=:equal, title=label, legend=false
         )
         rect_x = [-a, a, a, -a, -a]
         rect_y = [-b, -b, b, b, -b]
@@ -349,14 +369,14 @@ function _plot_window_box3d(
         if !isempty(inside)
             xs = [p[i] for p in inside]
             ys = [p[j] for p in inside]
-            Plots.scatter!(sub, xs, ys; marker=:circle, markersize=3,
-                           color=:darkorange)
+            Plots.scatter!(sub, xs, ys; marker=:circle, markersize=3, color=:darkorange)
         end
         if !isempty(outside)
             xs = [p[i] for p in outside]
             ys = [p[j] for p in outside]
-            Plots.scatter!(sub, xs, ys; marker=:circle, markersize=2,
-                           color=:gray, alpha=0.4)
+            Plots.scatter!(
+                sub, xs, ys; marker=:circle, markersize=2, color=:gray, alpha=0.4
+            )
         end
         push!(panels, sub)
     end

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -1,0 +1,373 @@
+module QuasiCrystalPlotsExt
+
+using QuasiCrystal
+using LatticeCore
+using StaticArrays
+using LinearAlgebra
+using Plots
+
+"""
+    QuasiCrystalPlotsExt
+
+Plots-backed visualisation extension. Provides
+
+- `visualize_quasicrystal_positions(qc; kwargs...)` — physical-space
+  scatter of a 1D or 2D quasicrystal point set.
+- `plot_acceptance_window(data; show_hyper_points, kwargs...)` —
+  cut-and-project acceptance window with optional overlay of the
+  hyper-lattice points projected to perpendicular space.
+
+Loaded automatically once `using Plots` runs in the same session as
+`using QuasiCrystal`. The function stubs themselves are declared in
+`src/utils/visualization.jl` so that the public API is visible even
+when `Plots` has not been loaded yet.
+"""
+QuasiCrystalPlotsExt
+
+# ====================================================================
+# visualize_quasicrystal_positions
+# ====================================================================
+
+function QuasiCrystal.visualize_quasicrystal_positions(
+    qc::QuasiCrystal.QuasicrystalData{1,T}; kwargs...
+) where {T}
+    positions_1d = [LatticeCore.position(qc, i)[1] for i in 1:LatticeCore.num_sites(qc)]
+    y_vals = zeros(length(positions_1d))
+
+    return Plots.scatter(
+        positions_1d,
+        y_vals;
+        marker=:circle,
+        markersize=6,
+        label="Sites",
+        ylims=(-0.5, 0.5),
+        yticks=[],
+        xlabel="Position",
+        title="1D Quasicrystal",
+        legend=:topright,
+        kwargs...,
+    )
+end
+
+function QuasiCrystal.visualize_quasicrystal_positions(
+    qc::QuasiCrystal.QuasicrystalData{2,T}; kwargs...
+) where {T}
+    x_vals = [LatticeCore.position(qc, i)[1] for i in 1:LatticeCore.num_sites(qc)]
+    y_vals = [LatticeCore.position(qc, i)[2] for i in 1:LatticeCore.num_sites(qc)]
+
+    return Plots.scatter(
+        x_vals,
+        y_vals;
+        marker=:circle,
+        markersize=3,
+        label="Vertices",
+        aspect_ratio=:equal,
+        xlabel="x",
+        ylabel="y",
+        title="2D Quasicrystal",
+        legend=:topright,
+        kwargs...,
+    )
+end
+
+# ====================================================================
+# plot_acceptance_window
+# ====================================================================
+
+# ---- public entry point --------------------------------------------
+
+function QuasiCrystal.plot_acceptance_window(
+    data::QuasiCrystal.QuasicrystalData;
+    show_hyper_points::Bool=true,
+    n_hyper::Union{Nothing,Int}=nothing,
+    kwargs...,
+)
+    shape = QuasiCrystal.window_shape(data)
+    if shape === :none
+        throw(
+            ArgumentError(
+                "plot_acceptance_window requires a cut-and-project quasicrystal " *
+                "with an explicit acceptance window; got window_shape == :none. " *
+                "Substitution-generated quasicrystals do not carry a perp-space window.",
+            ),
+        )
+    elseif shape === :unknown
+        throw(
+            ArgumentError(
+                "plot_acceptance_window cannot dispatch on window_shape == :unknown. " *
+                "Make sure `data.parameters[:window_shape]` is populated by the generator.",
+            ),
+        )
+    elseif shape === :interval_1d
+        return _plot_window_interval(data; show_hyper_points, n_hyper, kwargs...)
+    elseif shape === :box_2d
+        return _plot_window_box2d(data; show_hyper_points, n_hyper, kwargs...)
+    elseif shape === :box_3d
+        return _plot_window_box3d(data; show_hyper_points, n_hyper, kwargs...)
+    else
+        throw(
+            ArgumentError(
+                "plot_acceptance_window does not yet handle window_shape == :$(shape).",
+            ),
+        )
+    end
+end
+
+# ---- helpers --------------------------------------------------------
+
+# Pull the perp_proj matrix and a half-width vector for the
+# perpendicular acceptance window. The perp projection comes from
+# `hyper_reciprocal_lattice` (the canonical source of perp
+# geometry); the half-widths come from the generator's own
+# direct-space filter so that the "inside" / "outside" colouring
+# in the recipe matches the integer points the generator actually
+# accepts.
+function _perp_geometry(data::QuasiCrystal.QuasicrystalData)
+    hrl = QuasiCrystal.hyper_reciprocal_lattice(data)
+    hw = _direct_half_widths(data, hrl)
+    return (perp_proj=hrl.perp_proj, half_widths=hw)
+end
+
+# AB and Penrose store `:window_size` and use the same numeric
+# value on every perp axis. Fibonacci hardcodes `acceptance_width
+# = 1.0` (half-width 0.5) and does not stash it in `parameters`,
+# so we fall back on the generator's literal value there. If a
+# user supplies a custom generator that does record
+# `:window_size`, we honour it.
+function _direct_half_widths(
+    data::QuasiCrystal.QuasicrystalData,
+    hrl::LatticeCore.HyperReciprocalLattice,
+)
+    DPerp = size(hrl.perp_proj, 1)
+    if haskey(data.parameters, :window_size)
+        ws = Float64(data.parameters[:window_size])
+        return fill(ws, DPerp)
+    end
+    # Fibonacci-style generators with no :window_size key default
+    # to the orthonormal-frame half-width 0.5, matching
+    # `generate_fibonacci_projection`'s `abs(pos_perp) <= 0.5`
+    # filter. If a custom generator deviates from this convention
+    # it should populate `:window_size` explicitly.
+    return fill(0.5, DPerp)
+end
+
+# Default integer enumeration box. Penrose has DHyper = 5, so we keep
+# the radius small to avoid 11^5 ≈ 1.6e5 points dominating the figure.
+_default_n_hyper(::QuasiCrystal.QuasicrystalData{2,T,QuasiCrystal.PenroseP3}) where {T} = 3
+_default_n_hyper(::QuasiCrystal.QuasicrystalData) = 4
+
+# Enumerate every integer point in [-n, n]^DHyper exactly once,
+# returning their perpendicular-space projections. We strip the
+# `2π` factor that lives on `hyper_basis` because we want the
+# *direct-space* integer host points (Z^DHyper), not the reciprocal
+# ones — the educational picture is "which n ∈ Z^DHyper survive the
+# perp-window filter".
+function _projected_hyper_points(perp_proj::SMatrix{DPerp,DHyper,T}, n::Int) where {DPerp,DHyper,T}
+    pts = SVector{DPerp,Float64}[]
+    sizehint!(pts, (2n + 1)^DHyper)
+    ranges = ntuple(_ -> (-n):n, DHyper)
+    for idx in Iterators.product(ranges...)
+        v = SVector{DHyper,Float64}(ntuple(k -> Float64(idx[k]), DHyper))
+        push!(pts, perp_proj * v)
+    end
+    return pts
+end
+
+# Return (inside, outside) splits — Vector{SVector{DPerp,Float64}}
+# pairs — using axis-aligned half-widths.
+function _split_points(
+    pts::Vector{SVector{DPerp,Float64}}, half_widths::Vector{Float64}
+) where {DPerp}
+    inside = SVector{DPerp,Float64}[]
+    outside = SVector{DPerp,Float64}[]
+    @assert length(half_widths) == DPerp
+    for p in pts
+        if all(abs(p[d]) <= half_widths[d] for d in 1:DPerp)
+            push!(inside, p)
+        else
+            push!(outside, p)
+        end
+    end
+    return inside, outside
+end
+
+# ---- :interval_1d (Fibonacci) --------------------------------------
+
+function _plot_window_interval(
+    data::QuasiCrystal.QuasicrystalData;
+    show_hyper_points::Bool,
+    n_hyper::Union{Nothing,Int},
+    kwargs...,
+)
+    geom = _perp_geometry(data)
+    half = geom.half_widths[1]
+    n = n_hyper === nothing ? _default_n_hyper(data) : n_hyper
+
+    plt = Plots.plot(;
+        xlabel="perpendicular coordinate",
+        yticks=[],
+        ylims=(-1.0, 1.0),
+        title="Acceptance window (interval, Fibonacci)",
+        legend=:topright,
+        kwargs...,
+    )
+
+    # Window: thick segment on y = 0 with end caps.
+    Plots.plot!(
+        plt,
+        [-half, half],
+        [0.0, 0.0];
+        linewidth=4,
+        color=:steelblue,
+        label="window",
+    )
+    Plots.scatter!(plt, [-half, half], [0.0, 0.0]; marker=:vline, markersize=12,
+                   color=:steelblue, label="")
+
+    if show_hyper_points
+        pts = _projected_hyper_points(geom.perp_proj, n)
+        inside, outside = _split_points(pts, [half])
+        if !isempty(inside)
+            xs = [p[1] for p in inside]
+            ys = zeros(length(xs))
+            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=4,
+                           color=:darkorange, label="inside")
+        end
+        if !isempty(outside)
+            xs = [p[1] for p in outside]
+            ys = zeros(length(xs))
+            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=3,
+                           color=:gray, label="outside", alpha=0.5)
+        end
+    end
+
+    return plt
+end
+
+# ---- :box_2d (Ammann–Beenker) --------------------------------------
+
+function _plot_window_box2d(
+    data::QuasiCrystal.QuasicrystalData;
+    show_hyper_points::Bool,
+    n_hyper::Union{Nothing,Int},
+    kwargs...,
+)
+    geom = _perp_geometry(data)
+    hw = geom.half_widths
+    a, b = hw[1], hw[2]
+    n = n_hyper === nothing ? _default_n_hyper(data) : n_hyper
+
+    plt = Plots.plot(;
+        xlabel="y₁ (perp)",
+        ylabel="y₂ (perp)",
+        aspect_ratio=:equal,
+        title="Acceptance window (square, Ammann–Beenker)",
+        legend=:topright,
+        kwargs...,
+    )
+
+    # Filled rectangle.
+    rect_x = [-a, a, a, -a, -a]
+    rect_y = [-b, -b, b, b, -b]
+    Plots.plot!(
+        plt,
+        rect_x,
+        rect_y;
+        seriestype=:shape,
+        fillcolor=:steelblue,
+        fillalpha=0.2,
+        linecolor=:steelblue,
+        linewidth=2,
+        label="window",
+    )
+
+    if show_hyper_points
+        pts = _projected_hyper_points(geom.perp_proj, n)
+        inside, outside = _split_points(pts, hw)
+        if !isempty(inside)
+            xs = [p[1] for p in inside]
+            ys = [p[2] for p in inside]
+            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=4,
+                           color=:darkorange, label="inside")
+        end
+        if !isempty(outside)
+            xs = [p[1] for p in outside]
+            ys = [p[2] for p in outside]
+            Plots.scatter!(plt, xs, ys; marker=:circle, markersize=3,
+                           color=:gray, label="outside", alpha=0.5)
+        end
+    end
+
+    return plt
+end
+
+# ---- :box_3d (Penrose P3) ------------------------------------------
+#
+# We cannot draw a true 3D acceptance cube cleanly inside the
+# default Plots GR backend without surface meshes, so the recipe
+# falls back on the classic "three orthogonal projections" view —
+# the y₁y₂, y₁y₃, and y₂y₃ planes side by side — each carrying the
+# corresponding 2D rectangular window cross-section.
+
+function _plot_window_box3d(
+    data::QuasiCrystal.QuasicrystalData;
+    show_hyper_points::Bool,
+    n_hyper::Union{Nothing,Int},
+    kwargs...,
+)
+    geom = _perp_geometry(data)
+    hw = geom.half_widths
+    @assert length(hw) == 3
+    n = n_hyper === nothing ? _default_n_hyper(data) : n_hyper
+
+    pts = show_hyper_points ? _projected_hyper_points(geom.perp_proj, n) :
+        SVector{3,Float64}[]
+    inside, outside = _split_points(pts, hw)
+
+    panels = Plots.Plot[]
+    for (i, j, label) in ((1, 2, "y₁ vs y₂"), (1, 3, "y₁ vs y₃"), (2, 3, "y₂ vs y₃"))
+        a, b = hw[i], hw[j]
+        sub = Plots.plot(;
+            xlabel="y$(i)",
+            ylabel="y$(j)",
+            aspect_ratio=:equal,
+            title=label,
+            legend=false,
+        )
+        rect_x = [-a, a, a, -a, -a]
+        rect_y = [-b, -b, b, b, -b]
+        Plots.plot!(
+            sub,
+            rect_x,
+            rect_y;
+            seriestype=:shape,
+            fillcolor=:steelblue,
+            fillalpha=0.2,
+            linecolor=:steelblue,
+            linewidth=2,
+        )
+        if !isempty(inside)
+            xs = [p[i] for p in inside]
+            ys = [p[j] for p in inside]
+            Plots.scatter!(sub, xs, ys; marker=:circle, markersize=3,
+                           color=:darkorange)
+        end
+        if !isempty(outside)
+            xs = [p[i] for p in outside]
+            ys = [p[j] for p in outside]
+            Plots.scatter!(sub, xs, ys; marker=:circle, markersize=2,
+                           color=:gray, alpha=0.4)
+        end
+        push!(panels, sub)
+    end
+
+    return Plots.plot(
+        panels...;
+        layout=(1, 3),
+        plot_title="Acceptance window (cube, Penrose P3) — orthogonal projections",
+        size=(1200, 400),
+        kwargs...,
+    )
+end
+
+end # module QuasiCrystalPlotsExt

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -3,7 +3,6 @@ module QuasiCrystal
 using LinearAlgebra
 using SparseArrays
 using StaticArrays
-using Plots
 
 # ---- LatticeCore imports --------------------------------------------
 #
@@ -161,6 +160,7 @@ export window_shape
 export VERTEX_MERGE_TOL, SNAP_GRID_EPS, STAR_DIRECTION_TOL, positions_equal
 export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
+export plot_acceptance_window
 # Fourier analysis
 export IntervalWindow, BoxWindow, window_fourier
 export hyper_reciprocal_lattice, bragg_peaks

--- a/src/utils/visualization.jl
+++ b/src/utils/visualization.jl
@@ -1,60 +1,81 @@
 """
-Legacy visualisation helper for quasicrystal point sets.
+Plotting API stubs for quasicrystal visualisation.
 
-The long-term plan (see the migration PR discussion) is to replace
-this file with a [`LatticeCore`](@ref) package extension that
-provides a generic `plot_lattice(::AbstractLattice{D, T})` function
-shared between `Lattice2D` and `QuasiCrystal`. Until that lands,
-this module keeps a minimal Plots-based scatter routine so
-downstream notebooks that call `visualize_quasicrystal_positions`
-continue to work.
+The actual `Plots`-backed methods live in
+`QuasiCrystalPlotsExt` and are loaded automatically once the
+caller issues `using Plots`. This file only declares the public
+function names so that
+
+- `using QuasiCrystal` exports a stable symbol regardless of whether
+  `Plots` has been loaded yet, and
+- `?visualize_quasicrystal_positions` / `?plot_acceptance_window`
+  return useful documentation at the REPL even before the extension
+  has been triggered.
+
+Calling either function before `using Plots` raises a `MethodError`
+just like every other Julia generic — that is intentional and
+matches the behaviour of `LatticeCore.fourier_module` /
+`structure_factor` when their NUFFT extension is not loaded.
 """
 
 """
-    visualize_quasicrystal_positions(qc::QuasicrystalData{1, T}; kwargs...)
+    visualize_quasicrystal_positions(qc::QuasicrystalData{1,T}; kwargs...)
+    visualize_quasicrystal_positions(qc::QuasicrystalData{2,T}; kwargs...)
 
-Scatter a 1D quasicrystal's positions along a line. Requires
-`Plots` to be loaded at the call site.
+Scatter the physical positions of a quasicrystal point set.
+1D lattices render as a horizontal line of dots; 2D lattices render
+as a square-aspect scatter plot.
+
+This is a pedagogical / smoke-test helper. The real implementation
+ships in the `QuasiCrystalPlotsExt` package extension, so the call
+site must `using Plots` first. Without `Plots` loaded, dispatch
+falls through and Julia raises a `MethodError`.
+
+For the richer cut-and-project visualisation see
+[`plot_acceptance_window`](@ref).
 """
-function visualize_quasicrystal_positions(qc::QuasicrystalData{1,T}; kwargs...) where {T}
-    positions_1d = [position(qc, i)[1] for i in 1:num_sites(qc)]
-    y_vals = zeros(length(positions_1d))
-
-    return Plots.scatter(
-        positions_1d,
-        y_vals;
-        marker=:circle,
-        markersize=6,
-        label="Sites",
-        ylims=(-0.5, 0.5),
-        yticks=[],
-        xlabel="Position",
-        title="1D Quasicrystal",
-        legend=:topright,
-        kwargs...,
-    )
-end
+function visualize_quasicrystal_positions end
 
 """
-    visualize_quasicrystal_positions(qc::QuasicrystalData{2, T}; kwargs...)
+    plot_acceptance_window(data::QuasicrystalData; show_hyper_points=true, kwargs...)
 
-Scatter a 2D quasicrystal's positions. Requires `Plots`.
+Visualise the **acceptance window** of a cut-and-project
+quasicrystal `data`, optionally overlaying the integer
+hyper-lattice points projected onto perpendicular space.
+
+The recipe dispatches on [`window_shape`](@ref):
+
+| `window_shape(data)` | Drawn primitive                                       |
+|----------------------|-------------------------------------------------------|
+| `:interval_1d`       | Horizontal segment with the window endpoints          |
+| `:box_2d`            | Filled rectangle in the 2D perpendicular plane        |
+| `:box_3d`            | Three orthogonal projections of the perpendicular cube |
+| `:none` / `:unknown` | Raises `ArgumentError`                                |
+
+When `show_hyper_points = true` the recipe enumerates a bounded
+neighbourhood of the host lattice `Z^DHyper`, projects every point
+through `perp_proj`, and scatters them on top of the window:
+points inside the window (the ones that survive the cut-and-project
+filter) are drawn in one colour, points outside in a contrasting
+colour.
+
+This is meant as an **educational** visual: it gives a direct,
+geometric picture of the construction behind every `*_projection`
+generator. The number of hyper-lattice points enumerated is
+deliberately bounded so calls remain interactive in a notebook.
+
+`plot_acceptance_window` is shipped by the `QuasiCrystalPlotsExt`
+package extension; the caller must `using Plots` to trigger the
+extension before invoking the function.
+
+# Keyword arguments
+
+- `show_hyper_points::Bool = true` — overlay the projected
+  `Z^DHyper` lattice. Set to `false` to draw the window alone.
+- `n_hyper::Int` — half-width of the integer enumeration box per
+  axis. Defaults to a small value (3 for high-D Penrose, 4
+  otherwise) to keep the call cheap.
+- Any other keyword is forwarded to the underlying `Plots`
+  primitive (`title`, `size`, `markersize`, ...).
 """
-function visualize_quasicrystal_positions(qc::QuasicrystalData{2,T}; kwargs...) where {T}
-    x_vals = [position(qc, i)[1] for i in 1:num_sites(qc)]
-    y_vals = [position(qc, i)[2] for i in 1:num_sites(qc)]
-
-    return Plots.scatter(
-        x_vals,
-        y_vals;
-        marker=:circle,
-        markersize=3,
-        label="Vertices",
-        aspect_ratio=:equal,
-        xlabel="x",
-        ylabel="y",
-        title="2D Quasicrystal",
-        legend=:topright,
-        kwargs...,
-    )
-end
+function plot_acceptance_window end

--- a/test/model/test_plots_ext_acceptance_window.jl
+++ b/test/model/test_plots_ext_acceptance_window.jl
@@ -1,0 +1,64 @@
+using QuasiCrystal, Test, StaticArrays
+using Plots  # triggers QuasiCrystalPlotsExt
+
+@testset "plot_acceptance_window" begin
+    @testset "Fibonacci :interval_1d" begin
+        qc = generate_fibonacci_projection(40)
+        @test window_shape(qc) === :interval_1d
+
+        plt = plot_acceptance_window(qc; show_hyper_points=true, n_hyper=4)
+        @test plt isa Plots.Plot
+        # window line + inside scatter + outside scatter + endpoint vlines
+        @test length(plt.series_list) >= 2
+
+        plt2 = plot_acceptance_window(qc; show_hyper_points=false)
+        @test plt2 isa Plots.Plot
+    end
+
+    @testset "Ammann–Beenker :box_2d" begin
+        qc = generate_ammann_beenker_projection(2.0)
+        @test window_shape(qc) === :box_2d
+
+        plt = plot_acceptance_window(qc; show_hyper_points=true, n_hyper=3)
+        @test plt isa Plots.Plot
+        # rectangle (shape) + at least one scatter overlay
+        @test length(plt.series_list) >= 2
+
+        plt2 = plot_acceptance_window(qc; show_hyper_points=false)
+        @test plt2 isa Plots.Plot
+    end
+
+    @testset "Penrose P3 :box_3d" begin
+        qc = generate_penrose_projection(2.0)
+        @test window_shape(qc) === :box_3d
+
+        plt = plot_acceptance_window(qc; show_hyper_points=true, n_hyper=2)
+        @test plt isa Plots.Plot
+        # Three sub-panels (y₁y₂, y₁y₃, y₂y₃)
+        @test length(plt.subplots) >= 3
+
+        plt2 = plot_acceptance_window(qc; show_hyper_points=false, n_hyper=2)
+        @test plt2 isa Plots.Plot
+    end
+
+    @testset "substitution :none raises" begin
+        fib_s = generate_fibonacci_substitution(4)
+        @test window_shape(fib_s) === :none
+        @test_throws ArgumentError plot_acceptance_window(fib_s)
+
+        ab_s = generate_ammann_beenker_substitution(2)
+        @test window_shape(ab_s) === :none
+        @test_throws ArgumentError plot_acceptance_window(ab_s)
+
+        pen_s = generate_penrose_substitution(2)
+        @test window_shape(pen_s) === :none
+        @test_throws ArgumentError plot_acceptance_window(pen_s)
+    end
+
+    @testset "unknown window_shape raises" begin
+        qc = generate_fibonacci_projection(20)
+        delete!(qc.parameters, :window_shape)
+        @test window_shape(qc) === :unknown
+        @test_throws ArgumentError plot_acceptance_window(qc)
+    end
+end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,7 +4,7 @@ using QuasiCrystal
 @testset "Aqua quality checks" begin
     # Full Aqua sweep, with fine-grained skips below for known
     # cross-package method ambiguities (LatticeCore / NearestNeighbors).
-    Aqua.test_all(QuasiCrystal; ambiguities=false, stale_deps=(; ignore=[:Plots],))
+    Aqua.test_all(QuasiCrystal; ambiguities=false)
 
     # Run ambiguity check restricted to QuasiCrystal itself, so that
     # ambiguities introduced by upstream packages do not fail CI.


### PR DESCRIPTION
## Summary

- Add `QuasiCrystalPlotsExt` as a real package extension (`Plots` moves from `[deps]` to `[weakdeps]`) and ship a new pedagogical recipe `plot_acceptance_window(data; show_hyper_points=true, n_hyper, kwargs...)` that draws the perpendicular-space acceptance window of a cut-and-project quasicrystal together with the integer hyper-lattice points projected through `perp_proj`. Inside / outside points are colour-coded so the figure shows directly which `Z^DHyper` points survive the cut-and-project filter.
- Dispatch goes through `window_shape(data)`: `:interval_1d` → segment with end caps (Fibonacci), `:box_2d` → filled rectangle (Ammann–Beenker), `:box_3d` → three orthogonal projections of the perp cube (Penrose P3), `:none` / `:unknown` → `ArgumentError`.
- The half-widths used for the inside / outside split come from the generator's own `:window_size` parameter (with a 0.5 fallback for Fibonacci, which hardcodes `acceptance_width = 1.0`), so the colouring matches the points the generator actually accepts.
- The existing `visualize_quasicrystal_positions` 1D / 2D methods migrate into the extension as well; their stubs plus docstrings remain in `src/utils/visualization.jl` so the public API stays exported even before `using Plots` triggers the extension. The `:Plots` entry in Aqua's `stale_deps` ignore list is dropped.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — full suite passes (23650 / 23650), including Aqua quality checks
- [x] New test file `test/model/test_plots_ext_acceptance_window.jl` covers:
  - Fibonacci projection (`:interval_1d`) — recipe returns a `Plots.Plot` with the window line + scatter overlays, both with and without `show_hyper_points`
  - Ammann–Beenker projection (`:box_2d`) — same checks against a 2D rectangular window
  - Penrose P3 projection (`:box_3d`) — three sub-panels (`y₁y₂`, `y₁y₃`, `y₂y₃`)
  - All three substitution generators (`:none`) and a `:unknown` case raise `ArgumentError`