### PR TITLE
feat: plot_tiles recipe with semantic tile-type colouring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -9,18 +9,23 @@ using Plots
 """
     QuasiCrystalPlotsExt
 
-Plots-backed visualisation extension. Provides
+Optional Plots-backed visualisation extension. Loaded automatically
+once the user issues `using Plots` together with `using QuasiCrystal`.
+
+This extension provides the implementations for the public stubs
+declared in `src/utils/visualization.jl`:
 
 - `visualize_quasicrystal_positions(qc; kwargs...)` — physical-space
   scatter of a 1D or 2D quasicrystal point set.
 - `plot_acceptance_window(data; show_hyper_points, kwargs...)` —
   cut-and-project acceptance window with optional overlay of the
   hyper-lattice points projected to perpendicular space.
+- `plot_tiles(data; palette, ...)` — semantic tile-colouring recipe
+  for 2D quasicrystals; each tile is filled with a colour selected
+  from the active palette by its `TileType` tag.
 
-Loaded automatically once `using Plots` runs in the same session as
-`using QuasiCrystal`. The function stubs themselves are declared in
-`src/utils/visualization.jl` so that the public API is visible even
-when `Plots` has not been loaded yet.
+Keeping these in the extension keeps `Plots` out of the main module's
+load graph; users opt in by `using Plots`.
 """
 QuasiCrystalPlotsExt
 
@@ -31,8 +36,9 @@ QuasiCrystalPlotsExt
 function QuasiCrystal.visualize_quasicrystal_positions(
     qc::QuasiCrystal.QuasicrystalData{1,T}; kwargs...
 ) where {T}
-    positions_1d = [LatticeCore.position(qc, i)[1] for i in 1:LatticeCore.num_sites(qc)]
-    y_vals = zeros(length(positions_1d))
+    n = LatticeCore.num_sites(qc)
+    positions_1d = [LatticeCore.position(qc, i)[1] for i in 1:n]
+    y_vals = zeros(n)
 
     return Plots.scatter(
         positions_1d,
@@ -52,8 +58,9 @@ end
 function QuasiCrystal.visualize_quasicrystal_positions(
     qc::QuasiCrystal.QuasicrystalData{2,T}; kwargs...
 ) where {T}
-    x_vals = [LatticeCore.position(qc, i)[1] for i in 1:LatticeCore.num_sites(qc)]
-    y_vals = [LatticeCore.position(qc, i)[2] for i in 1:LatticeCore.num_sites(qc)]
+    n = LatticeCore.num_sites(qc)
+    x_vals = [LatticeCore.position(qc, i)[1] for i in 1:n]
+    y_vals = [LatticeCore.position(qc, i)[2] for i in 1:n]
 
     return Plots.scatter(
         x_vals,
@@ -73,8 +80,6 @@ end
 # ====================================================================
 # plot_acceptance_window
 # ====================================================================
-
-# ---- public entry point --------------------------------------------
 
 function QuasiCrystal.plot_acceptance_window(
     data::QuasiCrystal.QuasicrystalData;
@@ -107,7 +112,7 @@ function QuasiCrystal.plot_acceptance_window(
     else
         throw(
             ArgumentError(
-                "plot_acceptance_window does not yet handle window_shape == :$(shape)."
+                "plot_acceptance_window does not yet handle window_shape == :$(shape).",
             ),
         )
     end
@@ -115,25 +120,12 @@ end
 
 # ---- helpers --------------------------------------------------------
 
-# Pull the perp_proj matrix and a half-width vector for the
-# perpendicular acceptance window. The perp projection comes from
-# `hyper_reciprocal_lattice` (the canonical source of perp
-# geometry); the half-widths come from the generator's own
-# direct-space filter so that the "inside" / "outside" colouring
-# in the recipe matches the integer points the generator actually
-# accepts.
 function _perp_geometry(data::QuasiCrystal.QuasicrystalData)
     hrl = QuasiCrystal.hyper_reciprocal_lattice(data)
     hw = _direct_half_widths(data, hrl)
     return (perp_proj=hrl.perp_proj, half_widths=hw)
 end
 
-# AB and Penrose store `:window_size` and use the same numeric
-# value on every perp axis. Fibonacci hardcodes `acceptance_width
-# = 1.0` (half-width 0.5) and does not stash it in `parameters`,
-# so we fall back on the generator's literal value there. If a
-# user supplies a custom generator that does record
-# `:window_size`, we honour it.
 function _direct_half_widths(
     data::QuasiCrystal.QuasicrystalData, hrl::LatticeCore.HyperReciprocalLattice
 )
@@ -142,25 +134,12 @@ function _direct_half_widths(
         ws = Float64(data.parameters[:window_size])
         return fill(ws, DPerp)
     end
-    # Fibonacci-style generators with no :window_size key default
-    # to the orthonormal-frame half-width 0.5, matching
-    # `generate_fibonacci_projection`'s `abs(pos_perp) <= 0.5`
-    # filter. If a custom generator deviates from this convention
-    # it should populate `:window_size` explicitly.
     return fill(0.5, DPerp)
 end
 
-# Default integer enumeration box. Penrose has DHyper = 5, so we keep
-# the radius small to avoid 11^5 ≈ 1.6e5 points dominating the figure.
 _default_n_hyper(::QuasiCrystal.QuasicrystalData{2,T,QuasiCrystal.PenroseP3}) where {T} = 3
 _default_n_hyper(::QuasiCrystal.QuasicrystalData) = 4
 
-# Enumerate every integer point in [-n, n]^DHyper exactly once,
-# returning their perpendicular-space projections. We strip the
-# `2π` factor that lives on `hyper_basis` because we want the
-# *direct-space* integer host points (Z^DHyper), not the reciprocal
-# ones — the educational picture is "which n ∈ Z^DHyper survive the
-# perp-window filter".
 function _projected_hyper_points(
     perp_proj::SMatrix{DPerp,DHyper,T}, n::Int
 ) where {DPerp,DHyper,T}
@@ -174,8 +153,6 @@ function _projected_hyper_points(
     return pts
 end
 
-# Return (inside, outside) splits — Vector{SVector{DPerp,Float64}}
-# pairs — using axis-aligned half-widths.
 function _split_points(
     pts::Vector{SVector{DPerp,Float64}}, half_widths::Vector{Float64}
 ) where {DPerp}
@@ -213,7 +190,6 @@ function _plot_window_interval(
         kwargs...,
     )
 
-    # Window: thick segment on y = 0 with end caps.
     Plots.plot!(
         plt, [-half, half], [0.0, 0.0]; linewidth=4, color=:steelblue, label="window"
     )
@@ -278,7 +254,6 @@ function _plot_window_box2d(
         kwargs...,
     )
 
-    # Filled rectangle.
     rect_x = [-a, a, a, -a, -a]
     rect_y = [-b, -b, b, b, -b]
     Plots.plot!(
@@ -323,12 +298,6 @@ function _plot_window_box2d(
 end
 
 # ---- :box_3d (Penrose P3) ------------------------------------------
-#
-# We cannot draw a true 3D acceptance cube cleanly inside the
-# default Plots GR backend without surface meshes, so the recipe
-# falls back on the classic "three orthogonal projections" view —
-# the y₁y₂, y₁y₃, and y₂y₃ planes side by side — each carrying the
-# corresponding 2D rectangular window cross-section.
 
 function _plot_window_box3d(
     data::QuasiCrystal.QuasicrystalData;
@@ -388,6 +357,181 @@ function _plot_window_box3d(
         size=(1200, 400),
         kwargs...,
     )
+end
+
+# ====================================================================
+# plot_tiles -- semantic tile-type colouring
+# ====================================================================
+
+const _PALETTE_DEFAULT = Dict{QuasiCrystal.TileType,Any}(
+    QuasiCrystal.FatRhombus()  => RGB(0.96, 0.69, 0.36),
+    QuasiCrystal.ThinRhombus() => RGB(0.39, 0.55, 0.78),
+    QuasiCrystal.Square()      => RGB(0.34, 0.60, 0.74),
+    QuasiCrystal.RhombusAB()   => RGB(0.90, 0.55, 0.35),
+)
+
+const _PALETTE_PASTEL = Dict{QuasiCrystal.TileType,Any}(
+    QuasiCrystal.FatRhombus()  => RGB(0.99, 0.86, 0.71),
+    QuasiCrystal.ThinRhombus() => RGB(0.74, 0.83, 0.93),
+    QuasiCrystal.Square()      => RGB(0.74, 0.87, 0.91),
+    QuasiCrystal.RhombusAB()   => RGB(0.99, 0.81, 0.71),
+)
+
+const _PALETTE_BW = Dict{QuasiCrystal.TileType,Any}(
+    QuasiCrystal.FatRhombus()  => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.ThinRhombus() => RGB(0.55, 0.55, 0.55),
+    QuasiCrystal.Square()      => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.RhombusAB()   => RGB(0.55, 0.55, 0.55),
+)
+
+const _PALETTE_PRESETS = (:default, :pastel, :bw)
+
+function _resolve_palette(palette)
+    if palette isa Symbol
+        if palette === :default
+            return _PALETTE_DEFAULT
+        elseif palette === :pastel
+            return _PALETTE_PASTEL
+        elseif palette === :bw
+            return _PALETTE_BW
+        else
+            throw(
+                ArgumentError(
+                    "plot_tiles: unknown palette $(repr(palette)). " *
+                    "Use one of $(_PALETTE_PRESETS) or pass a " *
+                    "Dict{TileType, Color}.",
+                ),
+            )
+        end
+    elseif palette isa AbstractDict
+        merged = copy(_PALETTE_DEFAULT)
+        for (k, v) in palette
+            merged[k] = v
+        end
+        return merged
+    else
+        throw(
+            ArgumentError(
+                "plot_tiles: palette must be a preset Symbol " *
+                "$(_PALETTE_PRESETS) or a Dict{TileType, Color}; " *
+                "got $(typeof(palette)).",
+            ),
+        )
+    end
+end
+
+_tile_label(::QuasiCrystal.FatRhombus)  = "Fat rhombus"
+_tile_label(::QuasiCrystal.ThinRhombus) = "Thin rhombus"
+_tile_label(::QuasiCrystal.Square)      = "Square"
+_tile_label(::QuasiCrystal.RhombusAB)   = "Rhombus (AB)"
+_tile_label(t::QuasiCrystal.TileType)   = string(QuasiCrystal.tile_type_symbol(t))
+
+@inline function _tile_polygon_xy(tile::QuasiCrystal.Tile{2,T}) where {T}
+    v = tile.vertices
+    n = length(v)
+    xs = Vector{Float64}(undef, n + 1)
+    ys = Vector{Float64}(undef, n + 1)
+    @inbounds for k in 1:n
+        xs[k] = Float64(v[k][1])
+        ys[k] = Float64(v[k][2])
+    end
+    xs[n + 1] = xs[1]
+    ys[n + 1] = ys[1]
+    return xs, ys
+end
+
+function _group_tiles_by_type(tiles)
+    groups = Vector{Pair{QuasiCrystal.TileType,Vector{Int}}}()
+    seen = Dict{Any,Int}()
+    for (i, t) in enumerate(tiles)
+        ty = t.type
+        key = typeof(ty)
+        idx = get(seen, key, 0)
+        if idx == 0
+            push!(groups, ty => Int[i])
+            seen[key] = length(groups)
+        else
+            push!(groups[idx].second, i)
+        end
+    end
+    return groups
+end
+
+function QuasiCrystal.plot_tiles(
+    ::QuasiCrystal.QuasicrystalData{1,T}; kwargs...
+) where {T}
+    throw(
+        ArgumentError(
+            "plot_tiles: only 2D quasicrystals carry tiles; got D=1. " *
+            "Use visualize_quasicrystal_positions for 1D point sets.",
+        ),
+    )
+end
+
+function QuasiCrystal.plot_tiles(
+    data::QuasiCrystal.QuasicrystalData{2,T};
+    palette=:default,
+    show_boundary::Bool=true,
+    boundary_color=:black,
+    boundary_width::Real=0.5,
+    legend::Bool=true,
+    title::AbstractString="Quasicrystal tiling",
+    kwargs...,
+) where {T}
+    tiles = data.tiles
+    isempty(tiles) && throw(
+        ArgumentError(
+            "plot_tiles: data.tiles is empty. The projection-method " *
+            "generators do not currently populate tiles; use " *
+            "generate_*_substitution(...) instead.",
+        ),
+    )
+
+    pal = _resolve_palette(palette)
+
+    p = Plots.plot(;
+        aspect_ratio=:equal,
+        xlabel="x",
+        ylabel="y",
+        title=title,
+        legend=legend ? :topright : false,
+        kwargs...,
+    )
+
+    groups = _group_tiles_by_type(tiles)
+
+    for (tile_type, indices) in groups
+        fill_color = get(pal, tile_type, get(_PALETTE_DEFAULT, tile_type, :gray))
+        label = _tile_label(tile_type)
+
+        shapes = Vector{Plots.Shape}(undef, length(indices))
+        @inbounds for (k, i) in enumerate(indices)
+            xs, ys = _tile_polygon_xy(tiles[i])
+            shapes[k] = Plots.Shape(xs, ys)
+        end
+
+        if show_boundary
+            Plots.plot!(
+                p,
+                shapes;
+                fillcolor=fill_color,
+                linecolor=boundary_color,
+                linewidth=boundary_width,
+                label=label,
+            )
+        else
+            Plots.plot!(
+                p,
+                shapes;
+                fillcolor=fill_color,
+                linecolor=fill_color,
+                linewidth=0,
+                label=label,
+            )
+        end
+    end
+
+    return p
 end
 
 end # module QuasiCrystalPlotsExt

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -112,7 +112,7 @@ function QuasiCrystal.plot_acceptance_window(
     else
         throw(
             ArgumentError(
-                "plot_acceptance_window does not yet handle window_shape == :$(shape).",
+                "plot_acceptance_window does not yet handle window_shape == :$(shape)."
             ),
         )
     end
@@ -364,24 +364,24 @@ end
 # ====================================================================
 
 const _PALETTE_DEFAULT = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.96, 0.69, 0.36),
+    QuasiCrystal.FatRhombus() => RGB(0.96, 0.69, 0.36),
     QuasiCrystal.ThinRhombus() => RGB(0.39, 0.55, 0.78),
-    QuasiCrystal.Square()      => RGB(0.34, 0.60, 0.74),
-    QuasiCrystal.RhombusAB()   => RGB(0.90, 0.55, 0.35),
+    QuasiCrystal.Square() => RGB(0.34, 0.60, 0.74),
+    QuasiCrystal.RhombusAB() => RGB(0.90, 0.55, 0.35),
 )
 
 const _PALETTE_PASTEL = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.99, 0.86, 0.71),
+    QuasiCrystal.FatRhombus() => RGB(0.99, 0.86, 0.71),
     QuasiCrystal.ThinRhombus() => RGB(0.74, 0.83, 0.93),
-    QuasiCrystal.Square()      => RGB(0.74, 0.87, 0.91),
-    QuasiCrystal.RhombusAB()   => RGB(0.99, 0.81, 0.71),
+    QuasiCrystal.Square() => RGB(0.74, 0.87, 0.91),
+    QuasiCrystal.RhombusAB() => RGB(0.99, 0.81, 0.71),
 )
 
 const _PALETTE_BW = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.FatRhombus() => RGB(0.85, 0.85, 0.85),
     QuasiCrystal.ThinRhombus() => RGB(0.55, 0.55, 0.55),
-    QuasiCrystal.Square()      => RGB(0.85, 0.85, 0.85),
-    QuasiCrystal.RhombusAB()   => RGB(0.55, 0.55, 0.55),
+    QuasiCrystal.Square() => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.RhombusAB() => RGB(0.55, 0.55, 0.55),
 )
 
 const _PALETTE_PRESETS = (:default, :pastel, :bw)
@@ -420,11 +420,11 @@ function _resolve_palette(palette)
     end
 end
 
-_tile_label(::QuasiCrystal.FatRhombus)  = "Fat rhombus"
+_tile_label(::QuasiCrystal.FatRhombus) = "Fat rhombus"
 _tile_label(::QuasiCrystal.ThinRhombus) = "Thin rhombus"
-_tile_label(::QuasiCrystal.Square)      = "Square"
-_tile_label(::QuasiCrystal.RhombusAB)   = "Rhombus (AB)"
-_tile_label(t::QuasiCrystal.TileType)   = string(QuasiCrystal.tile_type_symbol(t))
+_tile_label(::QuasiCrystal.Square) = "Square"
+_tile_label(::QuasiCrystal.RhombusAB) = "Rhombus (AB)"
+_tile_label(t::QuasiCrystal.TileType) = string(QuasiCrystal.tile_type_symbol(t))
 
 @inline function _tile_polygon_xy(tile::QuasiCrystal.Tile{2,T}) where {T}
     v = tile.vertices
@@ -457,9 +457,7 @@ function _group_tiles_by_type(tiles)
     return groups
 end
 
-function QuasiCrystal.plot_tiles(
-    ::QuasiCrystal.QuasicrystalData{1,T}; kwargs...
-) where {T}
+function QuasiCrystal.plot_tiles(::QuasiCrystal.QuasicrystalData{1,T}; kwargs...) where {T}
     throw(
         ArgumentError(
             "plot_tiles: only 2D quasicrystals carry tiles; got D=1. " *

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -161,6 +161,7 @@ export VERTEX_MERGE_TOL, SNAP_GRID_EPS, STAR_DIRECTION_TOL, positions_equal
 export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
 export plot_acceptance_window
+export plot_tiles
 # Fourier analysis
 export IntervalWindow, BoxWindow, window_fourier
 export hyper_reciprocal_lattice, bragg_peaks

--- a/src/utils/visualization.jl
+++ b/src/utils/visualization.jl
@@ -1,38 +1,35 @@
 """
-Plotting API stubs for quasicrystal visualisation.
+Plots-based visualisation entry points for `QuasicrystalData`.
 
-The actual `Plots`-backed methods live in
-`QuasiCrystalPlotsExt` and are loaded automatically once the
-caller issues `using Plots`. This file only declares the public
-function names so that
+This file declares the public visualisation API as bare
+`function ... end` stubs. Real implementations live in the
+`QuasiCrystalPlotsExt` package extension
+(`ext/QuasiCrystalPlotsExt.jl`) and load automatically once the user
+issues `using Plots` together with `using QuasiCrystal`.
 
-- `using QuasiCrystal` exports a stable symbol regardless of whether
-  `Plots` has been loaded yet, and
-- `?visualize_quasicrystal_positions` / `?plot_acceptance_window`
-  return useful documentation at the REPL even before the extension
-  has been triggered.
+Keeping the stubs here lets QuasiCrystal export the symbols without
+forcing `Plots` (a comparatively heavy dependency) into every
+downstream load. Calling any of them before `Plots` is in scope
+produces the standard "no method matching" error from Julia, since
+no methods are defined until the extension activates.
 
-Calling either function before `using Plots` raises a `MethodError`
-just like every other Julia generic — that is intentional and
-matches the behaviour of `LatticeCore.fourier_module` /
-`structure_factor` when their NUFFT extension is not loaded.
+# API
+
+| Function                              | Purpose                                    |
+|---------------------------------------|--------------------------------------------|
+| [`visualize_quasicrystal_positions`]  | Scatter the site positions (1D / 2D).      |
+| [`plot_acceptance_window`]            | Cut-and-project window + hyper points.     |
+| [`plot_tiles`]                        | Polygon-fill 2D tiles, colour by type.     |
 """
 
 """
-    visualize_quasicrystal_positions(qc::QuasicrystalData{1,T}; kwargs...)
-    visualize_quasicrystal_positions(qc::QuasicrystalData{2,T}; kwargs...)
+    visualize_quasicrystal_positions(qc::QuasicrystalData{D, T}; kwargs...)
 
-Scatter the physical positions of a quasicrystal point set.
-1D lattices render as a horizontal line of dots; 2D lattices render
-as a square-aspect scatter plot.
+Scatter the vertex positions of `qc`. Implemented in
+`QuasiCrystalPlotsExt`; requires `using Plots` at the call site.
 
-This is a pedagogical / smoke-test helper. The real implementation
-ships in the `QuasiCrystalPlotsExt` package extension, so the call
-site must `using Plots` first. Without `Plots` loaded, dispatch
-falls through and Julia raises a `MethodError`.
-
-For the richer cut-and-project visualisation see
-[`plot_acceptance_window`](@ref).
+Supported dimensions are `D in {1, 2}`. Extra `kwargs` are forwarded
+to `Plots.scatter`.
 """
 function visualize_quasicrystal_positions end
 
@@ -59,11 +56,6 @@ points inside the window (the ones that survive the cut-and-project
 filter) are drawn in one colour, points outside in a contrasting
 colour.
 
-This is meant as an **educational** visual: it gives a direct,
-geometric picture of the construction behind every `*_projection`
-generator. The number of hyper-lattice points enumerated is
-deliberately bounded so calls remain interactive in a notebook.
-
 `plot_acceptance_window` is shipped by the `QuasiCrystalPlotsExt`
 package extension; the caller must `using Plots` to trigger the
 extension before invoking the function.
@@ -79,3 +71,75 @@ extension before invoking the function.
   primitive (`title`, `size`, `markersize`, ...).
 """
 function plot_acceptance_window end
+
+"""
+    plot_tiles(data::QuasicrystalData{2, T};
+               palette = :default,
+               show_boundary::Bool = true,
+               boundary_color = :black,
+               boundary_width::Real = 0.5,
+               legend::Bool = true,
+               kwargs...) -> Plots.Plot
+
+Render the 2D quasicrystalline tiling carried by `data` as a list of
+filled polygons, colouring each tile according to its semantic
+[`TileType`](@ref). Implemented in `QuasiCrystalPlotsExt`; requires
+`using Plots` at the call site.
+
+# Tile-type colouring
+
+Each tile is filled with the colour assigned to its `TileType`
+singleton. The `palette` keyword controls the assignment:
+
+- `palette = :default` -- a balanced two-tone scheme
+  (warm fat / cool thin for Penrose,
+  cool square / warm rhombus for Ammann-Beenker).
+- `palette = :pastel` -- softer pastel variants of the defaults.
+- `palette = :bw` -- light grey vs. dark grey for printer-friendly
+  black-and-white figures.
+- `palette::AbstractDict{<:TileType, <:Any}` -- explicit mapping;
+  any tile types not present in the dict fall back to the `:default`
+  palette, so a *partial* dict only overrides the listed types.
+
+# Boundary
+
+When `show_boundary` is `true` (default), the tile edges are stroked
+with `boundary_color` (default `:black`) and `boundary_width`
+(default `0.5`). Set `show_boundary = false` for a flat tile-fill
+render with no edges.
+
+# Legend
+
+When `legend = true` (default) one legend entry per distinct
+`TileType` is emitted (`"Fat rhombus"`, `"Thin rhombus"`, `"Square"`,
+`"Rhombus (AB)"`).
+
+Returns the `Plots.Plot` object so callers can compose with
+`plot!`, `savefig`, etc.
+
+# Examples
+
+```julia
+using Plots, QuasiCrystal
+qc = generate_penrose_substitution(3)
+plot_tiles(qc)                                # default palette
+plot_tiles(qc; palette = :pastel)             # pastel palette
+plot_tiles(qc; palette = :bw, legend = false) # B/W, no legend
+
+# Custom palette: only override the fat rhombus colour
+plot_tiles(qc; palette = Dict(FatRhombus() => :crimson))
+
+# Ammann-Beenker tiling, no edge strokes
+ab = generate_ammann_beenker_substitution(3)
+plot_tiles(ab; show_boundary = false)
+```
+
+# Errors
+
+- `ArgumentError` if `D != 2` (no tiles in 1D quasicrystals).
+- `ArgumentError` if `data.tiles` is empty (the projection-method
+  generators do not currently populate tiles; use a substitution
+  generator instead).
+- `ArgumentError` for an unknown `palette` symbol.
+"""
+function plot_tiles end

--- a/test/model/test_plot_tiles.jl
+++ b/test/model/test_plot_tiles.jl
@@ -1,0 +1,61 @@
+using Test
+using QuasiCrystal
+using Plots
+
+@testset "plot_tiles (Plots ext)" begin
+    @testset "Penrose tiles" begin
+        qc = generate_penrose_substitution(2)
+        @test !isempty(qc.tiles)
+
+        # Default palette path.
+        p = plot_tiles(qc)
+        @test p isa Plots.Plot
+
+        # Each preset must build without error.
+        for preset in (:default, :pastel, :bw)
+            @test plot_tiles(qc; palette=preset) isa Plots.Plot
+        end
+
+        # Custom Dict palette (partial dict -- unspecified types fall
+        # back to the :default palette).
+        custom = Dict{TileType,Any}(FatRhombus() => :crimson)
+        @test plot_tiles(qc; palette=custom) isa Plots.Plot
+
+        # Boundary toggle and legend toggle.
+        @test plot_tiles(qc; show_boundary=false) isa Plots.Plot
+        @test plot_tiles(qc; legend=false) isa Plots.Plot
+
+        # Custom title forwarded.
+        @test plot_tiles(qc; title="My Penrose") isa Plots.Plot
+    end
+
+    @testset "Ammann-Beenker tiles" begin
+        ab = generate_ammann_beenker_substitution(2)
+        @test !isempty(ab.tiles)
+
+        p = plot_tiles(ab)
+        @test p isa Plots.Plot
+
+        # Boundary toggle and explicit Square override.
+        custom = Dict{TileType,Any}(Square() => :gold)
+        @test plot_tiles(ab; palette=custom, show_boundary=false) isa Plots.Plot
+    end
+
+    @testset "Error paths" begin
+        # 1D quasicrystals do not carry tiles -- recipe must reject them.
+        fib = generate_fibonacci_substitution(4)
+        @test_throws ArgumentError plot_tiles(fib)
+
+        # Projection-method 2D generators do not populate tiles.
+        empty_qc = generate_penrose_projection(1.5)
+        @test isempty(empty_qc.tiles)
+        @test_throws ArgumentError plot_tiles(empty_qc)
+
+        # Unknown palette symbol.
+        qc = generate_penrose_substitution(1)
+        @test_throws ArgumentError plot_tiles(qc; palette=:nope)
+
+        # Wrong palette type (not Symbol or Dict).
+        @test_throws ArgumentError plot_tiles(qc; palette=42)
+    end
+end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -2,8 +2,10 @@ using Aqua
 using QuasiCrystal
 
 @testset "Aqua quality checks" begin
-    # Full Aqua sweep, with fine-grained skips below for known
-    # cross-package method ambiguities (LatticeCore / NearestNeighbors).
+    # Full Aqua sweep. Plots was previously ignored in `stale_deps`
+    # because the dispatch only fired through the top-level `using
+    # Plots`; it is now a `[weakdeps]` trigger for
+    # `QuasiCrystalPlotsExt` so the default Aqua check passes.
     Aqua.test_all(QuasiCrystal; ambiguities=false)
 
     # Run ambiguity check restricted to QuasiCrystal itself, so that


### PR DESCRIPTION
## Summary

- Add a Plots-backed `plot_tiles(data; palette, show_boundary, ...)` recipe in `QuasiCrystalPlotsExt` that renders 2D quasicrystal tilings as filled polygons coloured by their semantic `TileType` (`FatRhombus` / `ThinRhombus` for Penrose; `Square` / `RhombusAB` for Ammann-Beenker), with three palette presets (`:default`, `:pastel`, `:bw`) plus an explicit `Dict{TileType, Color}` form (partial dicts merge over `:default`).
- Move `Plots` from `[deps]` to `[weakdeps]` and host both the new `plot_tiles` and the existing `visualize_quasicrystal_positions` implementations in `ext/QuasiCrystalPlotsExt.jl`; the src-side stubs preserve the public API surface so `using QuasiCrystal` still exports the same names without forcing Plots into headless workflows. Drops the now-unnecessary `stale_deps = (; ignore = [:Plots])` Aqua skip.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` (23647 passed)
- [x] Plots-ext smoke tests in `test/model/test_plot_tiles.jl`: Penrose (default + each preset + custom Dict + boundary toggle + legend toggle + custom title), Ammann-Beenker (default + Square override), and error paths (1D rejection, empty `data.tiles`, unknown palette symbol, wrong palette type).
- [x] Aqua quality checks (`test_all` + ambiguities-only QuasiCrystal sweep) pass with the dropped `stale_deps` ignore.