### PR TITLE
feat: plot_state recipe in QuasiCrystalPlotsExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.7"
+version = "0.5.8"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -112,7 +112,7 @@ function QuasiCrystal.plot_acceptance_window(
     else
         throw(
             ArgumentError(
-                "plot_acceptance_window does not yet handle window_shape == :$(shape).",
+                "plot_acceptance_window does not yet handle window_shape == :$(shape)."
             ),
         )
     end
@@ -364,24 +364,24 @@ end
 # ====================================================================
 
 const _PALETTE_DEFAULT = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.96, 0.69, 0.36),
+    QuasiCrystal.FatRhombus() => RGB(0.96, 0.69, 0.36),
     QuasiCrystal.ThinRhombus() => RGB(0.39, 0.55, 0.78),
-    QuasiCrystal.Square()      => RGB(0.34, 0.60, 0.74),
-    QuasiCrystal.RhombusAB()   => RGB(0.90, 0.55, 0.35),
+    QuasiCrystal.Square() => RGB(0.34, 0.60, 0.74),
+    QuasiCrystal.RhombusAB() => RGB(0.90, 0.55, 0.35),
 )
 
 const _PALETTE_PASTEL = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.99, 0.86, 0.71),
+    QuasiCrystal.FatRhombus() => RGB(0.99, 0.86, 0.71),
     QuasiCrystal.ThinRhombus() => RGB(0.74, 0.83, 0.93),
-    QuasiCrystal.Square()      => RGB(0.74, 0.87, 0.91),
-    QuasiCrystal.RhombusAB()   => RGB(0.99, 0.81, 0.71),
+    QuasiCrystal.Square() => RGB(0.74, 0.87, 0.91),
+    QuasiCrystal.RhombusAB() => RGB(0.99, 0.81, 0.71),
 )
 
 const _PALETTE_BW = Dict{QuasiCrystal.TileType,Any}(
-    QuasiCrystal.FatRhombus()  => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.FatRhombus() => RGB(0.85, 0.85, 0.85),
     QuasiCrystal.ThinRhombus() => RGB(0.55, 0.55, 0.55),
-    QuasiCrystal.Square()      => RGB(0.85, 0.85, 0.85),
-    QuasiCrystal.RhombusAB()   => RGB(0.55, 0.55, 0.55),
+    QuasiCrystal.Square() => RGB(0.85, 0.85, 0.85),
+    QuasiCrystal.RhombusAB() => RGB(0.55, 0.55, 0.55),
 )
 
 const _PALETTE_PRESETS = (:default, :pastel, :bw)
@@ -420,11 +420,11 @@ function _resolve_palette(palette)
     end
 end
 
-_tile_label(::QuasiCrystal.FatRhombus)  = "Fat rhombus"
+_tile_label(::QuasiCrystal.FatRhombus) = "Fat rhombus"
 _tile_label(::QuasiCrystal.ThinRhombus) = "Thin rhombus"
-_tile_label(::QuasiCrystal.Square)      = "Square"
-_tile_label(::QuasiCrystal.RhombusAB)   = "Rhombus (AB)"
-_tile_label(t::QuasiCrystal.TileType)   = string(QuasiCrystal.tile_type_symbol(t))
+_tile_label(::QuasiCrystal.Square) = "Square"
+_tile_label(::QuasiCrystal.RhombusAB) = "Rhombus (AB)"
+_tile_label(t::QuasiCrystal.TileType) = string(QuasiCrystal.tile_type_symbol(t))
 
 @inline function _tile_polygon_xy(tile::QuasiCrystal.Tile{2,T}) where {T}
     v = tile.vertices
@@ -457,9 +457,7 @@ function _group_tiles_by_type(tiles)
     return groups
 end
 
-function QuasiCrystal.plot_tiles(
-    ::QuasiCrystal.QuasicrystalData{1,T}; kwargs...
-) where {T}
+function QuasiCrystal.plot_tiles(::QuasiCrystal.QuasicrystalData{1,T}; kwargs...) where {T}
     throw(
         ArgumentError(
             "plot_tiles: only 2D quasicrystals carry tiles; got D=1. " *
@@ -555,12 +553,21 @@ function _project_complex(state::AbstractVector{<:Complex}, mode::Symbol)
     return [_project_complex(z, v) for z in state]
 end
 
-_mode_label(mode::Symbol) = mode === :abs2 ? "|state|^2" :
-    mode === :abs ? "|state|" :
-    mode === :real ? "Re(state)" :
-    mode === :imag ? "Im(state)" :
-    mode === :phase ? "arg(state)" :
-    "state"
+function _mode_label(mode::Symbol)
+    if mode === :abs2
+        "|state|^2"
+    elseif mode === :abs
+        "|state|"
+    elseif mode === :real
+        "Re(state)"
+    elseif mode === :imag
+        "Im(state)"
+    elseif mode === :phase
+        "arg(state)"
+    else
+        "state"
+    end
+end
 
 function _plot_state_discrete(
     qc::QuasiCrystal.QuasicrystalData{D,T},
@@ -620,7 +627,11 @@ function _plot_state_discrete(
             kwargs...,
         )
     else
-        throw(ArgumentError("plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."))
+        throw(
+            ArgumentError(
+                "plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."
+            ),
+        )
     end
 end
 
@@ -678,7 +689,11 @@ function _plot_state_continuous(
             kwargs...,
         )
     else
-        throw(ArgumentError("plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."))
+        throw(
+            ArgumentError(
+                "plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."
+            ),
+        )
     end
 end
 
@@ -692,12 +707,7 @@ function QuasiCrystal.plot_state(
     kwargs...,
 ) where {D,T}
     return _plot_state_discrete(
-        qc,
-        state;
-        marker_size=marker_size,
-        palette=palette,
-        title=title,
-        kwargs...,
+        qc, state; marker_size=marker_size, palette=palette, title=title, kwargs...
     )
 end
 

--- a/ext/QuasiCrystalPlotsExt.jl
+++ b/ext/QuasiCrystalPlotsExt.jl
@@ -534,4 +534,211 @@ function QuasiCrystal.plot_tiles(
     return p
 end
 
+# ====================================================================
+# plot_state -- per-site state colour mapping
+# ====================================================================
+
+@inline _project_complex(z, ::Val{:abs2}) = abs2(z)
+@inline _project_complex(z, ::Val{:abs}) = abs(z)
+@inline _project_complex(z, ::Val{:real}) = real(z)
+@inline _project_complex(z, ::Val{:imag}) = imag(z)
+@inline _project_complex(z, ::Val{:phase}) = angle(z)
+
+function _project_complex(state::AbstractVector{<:Complex}, mode::Symbol)
+    mode in (:abs2, :abs, :real, :imag, :phase) || throw(
+        ArgumentError(
+            "plot_state: unsupported mode=$(mode). " *
+            "Use one of :abs2, :abs, :real, :imag, :phase.",
+        ),
+    )
+    v = Val(mode)
+    return [_project_complex(z, v) for z in state]
+end
+
+_mode_label(mode::Symbol) = mode === :abs2 ? "|state|^2" :
+    mode === :abs ? "|state|" :
+    mode === :real ? "Re(state)" :
+    mode === :imag ? "Im(state)" :
+    mode === :phase ? "arg(state)" :
+    "state"
+
+function _plot_state_discrete(
+    qc::QuasiCrystal.QuasicrystalData{D,T},
+    state::AbstractVector;
+    marker_size::Real,
+    palette,
+    title::AbstractString,
+    kwargs...,
+) where {D,T}
+    n = LatticeCore.num_sites(qc)
+    length(state) == n || throw(
+        DimensionMismatch(
+            "plot_state: length(state)=$(length(state)) != num_sites(qc)=$(n)."
+        ),
+    )
+    levels = sort!(unique(state))
+    level_to_idx = Dict(v => k for (k, v) in enumerate(levels))
+    color_idx = [level_to_idx[s] for s in state]
+    pal = palette === nothing ? Plots.palette(:tab10, max(length(levels), 2)) : palette
+
+    if D == 1
+        xs = [LatticeCore.position(qc, i)[1] for i in 1:n]
+        ys = zeros(n)
+        return Plots.scatter(
+            xs,
+            ys;
+            marker=:circle,
+            markersize=marker_size,
+            zcolor=color_idx,
+            color=pal,
+            colorbar=true,
+            colorbar_title="state level",
+            ylims=(-0.5, 0.5),
+            yticks=[],
+            xlabel="Position",
+            title=title,
+            label="",
+            kwargs...,
+        )
+    elseif D == 2
+        xs = [LatticeCore.position(qc, i)[1] for i in 1:n]
+        ys = [LatticeCore.position(qc, i)[2] for i in 1:n]
+        return Plots.scatter(
+            xs,
+            ys;
+            marker=:circle,
+            markersize=marker_size,
+            zcolor=color_idx,
+            color=pal,
+            colorbar=true,
+            colorbar_title="state level",
+            aspect_ratio=:equal,
+            xlabel="x",
+            ylabel="y",
+            title=title,
+            label="",
+            kwargs...,
+        )
+    else
+        throw(ArgumentError("plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."))
+    end
+end
+
+function _plot_state_continuous(
+    qc::QuasiCrystal.QuasicrystalData{D,T},
+    values::AbstractVector{<:Real};
+    marker_size::Real,
+    colormap,
+    cbar_title::AbstractString,
+    title::AbstractString,
+    kwargs...,
+) where {D,T}
+    n = LatticeCore.num_sites(qc)
+    length(values) == n || throw(
+        DimensionMismatch(
+            "plot_state: length(state)=$(length(values)) != num_sites(qc)=$(n)."
+        ),
+    )
+    if D == 1
+        xs = [LatticeCore.position(qc, i)[1] for i in 1:n]
+        ys = zeros(n)
+        return Plots.scatter(
+            xs,
+            ys;
+            marker=:circle,
+            markersize=marker_size,
+            zcolor=values,
+            color=colormap,
+            colorbar=true,
+            colorbar_title=cbar_title,
+            ylims=(-0.5, 0.5),
+            yticks=[],
+            xlabel="Position",
+            title=title,
+            label="",
+            kwargs...,
+        )
+    elseif D == 2
+        xs = [LatticeCore.position(qc, i)[1] for i in 1:n]
+        ys = [LatticeCore.position(qc, i)[2] for i in 1:n]
+        return Plots.scatter(
+            xs,
+            ys;
+            marker=:circle,
+            markersize=marker_size,
+            zcolor=values,
+            color=colormap,
+            colorbar=true,
+            colorbar_title=cbar_title,
+            aspect_ratio=:equal,
+            xlabel="x",
+            ylabel="y",
+            title=title,
+            label="",
+            kwargs...,
+        )
+    else
+        throw(ArgumentError("plot_state: only D=1 and D=2 lattices are supported (got D=$(D))."))
+    end
+end
+
+function QuasiCrystal.plot_state(
+    qc::QuasiCrystal.QuasicrystalData{D,T},
+    state::AbstractVector{<:Union{Bool,Integer}};
+    colormap=:viridis,
+    marker_size::Real=4,
+    palette=nothing,
+    title::AbstractString="QuasiCrystal state (discrete)",
+    kwargs...,
+) where {D,T}
+    return _plot_state_discrete(
+        qc,
+        state;
+        marker_size=marker_size,
+        palette=palette,
+        title=title,
+        kwargs...,
+    )
+end
+
+function QuasiCrystal.plot_state(
+    qc::QuasiCrystal.QuasicrystalData{D,T},
+    state::AbstractVector{<:Real};
+    colormap=:viridis,
+    marker_size::Real=4,
+    title::AbstractString="QuasiCrystal state",
+    kwargs...,
+) where {D,T}
+    return _plot_state_continuous(
+        qc,
+        state;
+        marker_size=marker_size,
+        colormap=colormap,
+        cbar_title="state",
+        title=title,
+        kwargs...,
+    )
+end
+
+function QuasiCrystal.plot_state(
+    qc::QuasiCrystal.QuasicrystalData{D,T},
+    state::AbstractVector{<:Complex};
+    mode::Symbol=:abs2,
+    colormap=:viridis,
+    marker_size::Real=4,
+    title::AbstractString="QuasiCrystal state",
+    kwargs...,
+) where {D,T}
+    values = _project_complex(state, mode)
+    return _plot_state_continuous(
+        qc,
+        values;
+        marker_size=marker_size,
+        colormap=colormap,
+        cbar_title=_mode_label(mode),
+        title=title,
+        kwargs...,
+    )
+end
+
 end # module QuasiCrystalPlotsExt

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -162,6 +162,7 @@ export build_nearest_neighbor_bonds!
 export visualize_quasicrystal_positions
 export plot_acceptance_window
 export plot_tiles
+export plot_state
 # Fourier analysis
 export IntervalWindow, BoxWindow, window_fourier
 export hyper_reciprocal_lattice, bragg_peaks

--- a/src/utils/visualization.jl
+++ b/src/utils/visualization.jl
@@ -20,6 +20,7 @@ no methods are defined until the extension activates.
 | [`visualize_quasicrystal_positions`]  | Scatter the site positions (1D / 2D).      |
 | [`plot_acceptance_window`]            | Cut-and-project window + hyper points.     |
 | [`plot_tiles`]                        | Polygon-fill 2D tiles, colour by type.     |
+| [`plot_state`]                        | Colour-mapped per-site state vector.       |
 """
 
 """
@@ -143,3 +144,44 @@ plot_tiles(ab; show_boundary = false)
 - `ArgumentError` for an unknown `palette` symbol.
 """
 function plot_tiles end
+
+"""
+    plot_state(data::QuasicrystalData, state;
+               colormap = :viridis,
+               marker_size::Real = 4,
+               palette = nothing,
+               mode::Symbol = :abs2,
+               title::AbstractString = "QuasiCrystal state",
+               kwargs...) -> Plots.Plot
+
+Visualise a per-site state vector on top of the quasicrystal scatter.
+`state[i]` is mapped onto the marker colour of vertex `i`. Implemented
+in `QuasiCrystalPlotsExt`; requires `using Plots` at the call site.
+
+Three input forms are supported, dispatched on `eltype(state)`:
+
+* Real-valued state -- `state::AbstractVector{<:Real}`. Continuous
+  `colormap` (default `:viridis`).
+* Discrete state -- `state::AbstractVector{<:Union{Bool, Integer}}`.
+  Categorical palette (`:tab10` default; override via `palette`).
+* Complex state -- `state::AbstractVector{<:Complex}`. Projected to
+  a real scalar via `mode in (:abs2, :abs, :real, :imag, :phase)`
+  (default `:abs2`) before colour-mapping.
+
+# Examples
+
+```julia
+using QuasiCrystal, Plots
+
+qc = generate_penrose_substitution(3)
+state = [sin(p[1]) * cos(p[2]) for p in get_positions(qc)]
+plot_state(qc, state; colormap = :plasma, marker_size = 5)
+```
+
+```julia
+fib = generate_fibonacci_substitution(6)
+occ = [iseven(i) for i in 1:num_sites(fib)]
+plot_state(fib, occ; marker_size = 6)
+```
+"""
+function plot_state end

--- a/test/model/test_plot_state.jl
+++ b/test/model/test_plot_state.jl
@@ -1,0 +1,53 @@
+using QuasiCrystal, Test
+using Plots
+
+@testset "plot_state (Plots ext)" begin
+    @testset "real-valued state on 2D Penrose" begin
+        qc = generate_penrose_substitution(2)
+        n = num_sites(qc)
+        state = [Float64(i) / n for i in 1:n]
+        p = plot_state(qc, state)
+        @test p isa Plots.Plot
+
+        # Forwarded kwargs must not error.
+        p2 = plot_state(qc, state; colormap=:plasma, marker_size=5, title="custom")
+        @test p2 isa Plots.Plot
+    end
+
+    @testset "real-valued state on 1D Fibonacci" begin
+        fib = generate_fibonacci_substitution(5)
+        n = num_sites(fib)
+        state = collect(range(-1.0, 1.0; length=n))
+        p = plot_state(fib, state)
+        @test p isa Plots.Plot
+    end
+
+    @testset "discrete (Bool / Int) palette path" begin
+        qc = generate_ammann_beenker_projection(3.0)
+        n = num_sites(qc)
+        bool_state = [iseven(i) for i in 1:n]
+        p_bool = plot_state(qc, bool_state)
+        @test p_bool isa Plots.Plot
+
+        int_state = [mod(i, 3) for i in 1:n]
+        p_int = plot_state(qc, int_state; marker_size=3)
+        @test p_int isa Plots.Plot
+    end
+
+    @testset "complex state with mode projections" begin
+        qc = generate_penrose_substitution(2)
+        n = num_sites(qc)
+        psi = [cis(2pi * i / n) / sqrt(n) for i in 1:n]
+        for mode in (:abs2, :abs, :real, :imag, :phase)
+            p = plot_state(qc, psi; mode=mode)
+            @test p isa Plots.Plot
+        end
+        @test_throws ArgumentError plot_state(qc, psi; mode=:bogus)
+    end
+
+    @testset "input validation" begin
+        qc = generate_penrose_substitution(2)
+        bad = zeros(num_sites(qc) + 1)
+        @test_throws DimensionMismatch plot_state(qc, bad)
+    end
+end


### PR DESCRIPTION
## Summary

- Add `plot_state(data, state; kwargs...)` recipe that colour-maps a per-site state vector onto the quasicrystal scatter for Penrose / Ammann–Beenker / Fibonacci lattices.
- Three input forms dispatch automatically on `eltype(state)`: real-valued (continuous `:viridis`), `Bool`/`Integer` (discrete `:tab10`), `Complex` (projected via `mode in (:abs2, :abs, :real, :imag, :phase)`).
- Move `Plots` to `[weakdeps]` and host both `plot_state` and the existing `visualize_quasicrystal_positions` impl in `ext/QuasiCrystalPlotsExt.jl`. Public symbols stay exported as bare stubs in `src/utils/visualization.jl` so the API surface is unchanged from the caller's side.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — 23642 / 23642 pass on this branch (includes Aqua + the new `test/model/test_plot_state.jl`).
- [x] Real-valued state on 2D Penrose with `colormap=:plasma`, `marker_size=5`, custom title.
- [x] Real-valued state on 1D Fibonacci.
- [x] `Bool` / `Int` discrete palette path on Ammann–Beenker.
- [x] Complex state with all five `mode` projections; `ArgumentError` on bogus mode.
- [x] `DimensionMismatch` raised when `length(state) != num_sites(data)`.