### PR TITLE
feat: convenience builder API for quasicrystal generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.10"
+version = "0.5.11"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -134,6 +134,7 @@ include("core/fourier/fourier.jl")
 include("analysis/tile_statistics.jl")
 include("utils/visualization.jl")
 include("analysis/vertex_coordination.jl")
+include("api/builders.jl")
 
 # ---- Exports ---------------------------------------------------------
 
@@ -158,6 +159,9 @@ export generate_fibonacci_projection, generate_fibonacci_substitution
 export generate_penrose_projection, generate_penrose_substitution
 export generate_ammann_beenker_projection, generate_ammann_beenker_substitution
 export fibonacci_sequence_length
+# Convenience builder API (thin wrappers, see src/api/builders.jl)
+export fibonacci, penrose, ammann_beenker
+export fibonacci_projected, penrose_projected, ammann_beenker_projected
 export build_quasicrystal
 export get_positions, get_bonds, get_nearest_neighbors, num_bonds
 export num_plaquettes, bond_type

--- a/src/analysis/tile_statistics.jl
+++ b/src/analysis/tile_statistics.jl
@@ -31,7 +31,7 @@ in `data.tiles` to the number of tiles of that type. Returns an empty
 dict for tilings without tiles (e.g. 1D Fibonacci, where the chain is
 described purely by site positions).
 
-```jldoctest
+```jldoctest; setup = :(using QuasiCrystal)
 julia> qc = generate_penrose_substitution(3);
 
 julia> counts = tile_counts(qc);

--- a/src/api/builders.jl
+++ b/src/api/builders.jl
@@ -1,0 +1,132 @@
+"""
+Convenience builder API: thin one-liner wrappers around the
+`generate_*_substitution` and `generate_*_projection` family that
+ship the most commonly-used defaults so callers do not have to
+remember per-family argument names.
+
+These builders are pure delegators: they construct no new state,
+they only forward keyword arguments to the canonical generators.
+The returned `QuasicrystalData` is identical (`===`-equal in
+field-by-field semantics) to what the underlying `generate_*`
+function would have produced.
+
+# Naming
+
+| Builder                      | Underlying generator                     |
+|------------------------------|------------------------------------------|
+| `fibonacci(n)`               | `generate_fibonacci_substitution(n)`     |
+| `penrose(n)`                 | `generate_penrose_substitution(n)`       |
+| `ammann_beenker(n)`          | `generate_ammann_beenker_substitution(n)`|
+| `penrose_projected(r)`       | `generate_penrose_projection(r)`         |
+| `ammann_beenker_projected(r)`| `generate_ammann_beenker_projection(r)`  |
+
+The substitution-route builders default to a small number of
+generations so a bare `penrose()` returns a usable point set
+without explicit arguments. The projection-route builders take a
+positional `radius` because there is no universally sensible
+default that scales gracefully with use case.
+"""
+
+"""
+    penrose(n::Int = 3; method = SubstitutionMethod(DefaultSubstitution()))
+        → QuasicrystalData{2, Float64, PenroseP3}
+
+Build a Penrose P3 quasicrystal via `n` substitution generations.
+Equivalent to `generate_penrose_substitution(n; method=method)`.
+
+`method` accepts either an `AbstractSubstitutionAlgorithm` (which
+will be wrapped in a `SubstitutionMethod`) or a fully-formed
+`SubstitutionMethod`.
+"""
+function penrose(
+    n::Int=3;
+    method::Union{SubstitutionMethod,AbstractSubstitutionAlgorithm}=SubstitutionMethod(),
+)
+    return generate_penrose_substitution(n; method=_as_substitution_method(method))
+end
+
+"""
+    ammann_beenker(n::Int = 3; method = SubstitutionMethod(DefaultSubstitution()))
+        → QuasicrystalData{2, Float64, AmmannBeenker}
+
+Build an Ammann–Beenker quasicrystal via `n` substitution
+generations. Equivalent to
+`generate_ammann_beenker_substitution(n; method=method)`.
+"""
+function ammann_beenker(
+    n::Int=3;
+    method::Union{SubstitutionMethod,AbstractSubstitutionAlgorithm}=SubstitutionMethod(),
+)
+    return generate_ammann_beenker_substitution(
+        n; method=_as_substitution_method(method)
+    )
+end
+
+"""
+    fibonacci(n::Int = 10) → QuasicrystalData{1, Float64, FibonacciLattice}
+
+Build a 1D Fibonacci chain via `n` substitution generations.
+Equivalent to `generate_fibonacci_substitution(n)`. The default
+`n = 10` produces a chain of `fibonacci_sequence_length(10) + 1`
+sites — large enough for typical inspection / plotting but still
+cheap to construct.
+"""
+function fibonacci(
+    n::Int=10;
+    method::Union{SubstitutionMethod,AbstractSubstitutionAlgorithm}=SubstitutionMethod(),
+)
+    return generate_fibonacci_substitution(n; method=_as_substitution_method(method))
+end
+
+"""
+    penrose_projected(radius::Real = 5.0; method = ProjectionMethod())
+        → QuasicrystalData{2, Float64, PenroseP3}
+
+Build a Penrose P3 quasicrystal via the cut-and-project route with
+physical-space radius `radius`. Equivalent to
+`generate_penrose_projection(radius; method=method)`.
+
+The default `radius = 5.0` is large enough to expose 5-fold
+rotational symmetry while staying cheap to construct.
+"""
+function penrose_projected(
+    radius::Real=5.0; method::ProjectionMethod=ProjectionMethod()
+)
+    return generate_penrose_projection(radius; method=method)
+end
+
+"""
+    ammann_beenker_projected(radius::Real = 5.0; method = ProjectionMethod())
+        → QuasicrystalData{2, Float64, AmmannBeenker}
+
+Build an Ammann–Beenker quasicrystal via the cut-and-project route
+with physical-space radius `radius`. Equivalent to
+`generate_ammann_beenker_projection(radius; method=method)`.
+"""
+function ammann_beenker_projected(
+    radius::Real=5.0; method::ProjectionMethod=ProjectionMethod()
+)
+    return generate_ammann_beenker_projection(radius; method=method)
+end
+
+"""
+    fibonacci_projected(n_points::Int = 100; method = ProjectionMethod())
+        → QuasicrystalData{1, Float64, FibonacciLattice}
+
+Build a 1D Fibonacci chain via the cut-and-project route, taking
+the first `n_points` projected sites. Equivalent to
+`generate_fibonacci_projection(n_points; method=method)`.
+"""
+function fibonacci_projected(
+    n_points::Int=100; method::ProjectionMethod=ProjectionMethod()
+)
+    return generate_fibonacci_projection(n_points; method=method)
+end
+
+# ---- Internal helpers -----------------------------------------------
+
+# Accept either a fully-formed `SubstitutionMethod` or a bare
+# algorithm singleton (so callers can write `method=DefaultSubstitution()`
+# and have it wrapped automatically).
+_as_substitution_method(m::SubstitutionMethod) = m
+_as_substitution_method(alg::AbstractSubstitutionAlgorithm) = SubstitutionMethod(alg)

--- a/src/api/builders.jl
+++ b/src/api/builders.jl
@@ -57,9 +57,7 @@ function ammann_beenker(
     n::Int=3;
     method::Union{SubstitutionMethod,AbstractSubstitutionAlgorithm}=SubstitutionMethod(),
 )
-    return generate_ammann_beenker_substitution(
-        n; method=_as_substitution_method(method)
-    )
+    return generate_ammann_beenker_substitution(n; method=_as_substitution_method(method))
 end
 
 """
@@ -89,9 +87,7 @@ physical-space radius `radius`. Equivalent to
 The default `radius = 5.0` is large enough to expose 5-fold
 rotational symmetry while staying cheap to construct.
 """
-function penrose_projected(
-    radius::Real=5.0; method::ProjectionMethod=ProjectionMethod()
-)
+function penrose_projected(radius::Real=5.0; method::ProjectionMethod=ProjectionMethod())
     return generate_penrose_projection(radius; method=method)
 end
 
@@ -117,9 +113,7 @@ Build a 1D Fibonacci chain via the cut-and-project route, taking
 the first `n_points` projected sites. Equivalent to
 `generate_fibonacci_projection(n_points; method=method)`.
 """
-function fibonacci_projected(
-    n_points::Int=100; method::ProjectionMethod=ProjectionMethod()
-)
+function fibonacci_projected(n_points::Int=100; method::ProjectionMethod=ProjectionMethod())
     return generate_fibonacci_projection(n_points; method=method)
 end
 

--- a/test/api/test_builders.jl
+++ b/test/api/test_builders.jl
@@ -1,0 +1,102 @@
+@testset "convenience builder API" begin
+    @testset "fibonacci(n) substitution shortcut" begin
+        qc = fibonacci(4)
+        @test qc isa QuasicrystalData{1,Float64}
+        @test qc.topology isa FibonacciLattice
+        @test qc.generation_method isa SubstitutionMethod
+        @test qc.parameters[:generations] == 4
+        # Defaults to 10 generations.
+        qc_default = fibonacci()
+        @test qc_default.parameters[:generations] == 10
+        @test num_sites(qc_default) > num_sites(qc)
+        # Underlying generator and shortcut produce identical positions.
+        ref = generate_fibonacci_substitution(4)
+        @test num_sites(qc) == num_sites(ref)
+        @test position(qc, 1) == position(ref, 1)
+        @test position(qc, num_sites(qc)) == position(ref, num_sites(ref))
+    end
+
+    @testset "penrose(n) substitution shortcut" begin
+        qc = penrose(2)
+        @test qc isa QuasicrystalData{2,Float64}
+        @test qc.topology isa PenroseP3
+        @test qc.generation_method isa SubstitutionMethod
+        @test qc.parameters[:generations] == 2
+        # Defaults to 3 generations.
+        qc_default = penrose()
+        @test qc_default.parameters[:generations] == 3
+        # Forwarded `method` keyword is preserved on the data.
+        qc_alg = penrose(2; method=DefaultSubstitution())
+        @test qc_alg.generation_method isa SubstitutionMethod
+        @test qc_alg.generation_method.algorithm isa DefaultSubstitution
+        # Bare-algorithm and wrapped-method calls agree.
+        qc_wrapped = penrose(2; method=SubstitutionMethod(DefaultSubstitution()))
+        @test num_sites(qc_alg) == num_sites(qc_wrapped)
+    end
+
+    @testset "ammann_beenker(n) substitution shortcut" begin
+        qc = ammann_beenker(2)
+        @test qc isa QuasicrystalData{2,Float64}
+        @test qc.topology isa AmmannBeenker
+        @test qc.generation_method isa SubstitutionMethod
+        @test qc.parameters[:generations] == 2
+        @test qc.parameters[:symmetry] == 8
+        # Default generations.
+        qc_default = ammann_beenker()
+        @test qc_default.parameters[:generations] == 3
+    end
+
+    @testset "penrose_projected(radius) projection shortcut" begin
+        qc = penrose_projected(3.0)
+        @test qc isa QuasicrystalData{2,Float64}
+        @test qc.topology isa PenroseP3
+        @test qc.generation_method isa ProjectionMethod
+        @test qc.parameters[:radius] == 3.0
+        # Reference equality with the canonical generator.
+        ref = generate_penrose_projection(3.0)
+        @test num_sites(qc) == num_sites(ref)
+    end
+
+    @testset "ammann_beenker_projected(radius) projection shortcut" begin
+        qc = ammann_beenker_projected(3.0)
+        @test qc isa QuasicrystalData{2,Float64}
+        @test qc.topology isa AmmannBeenker
+        @test qc.generation_method isa ProjectionMethod
+        @test qc.parameters[:radius] == 3.0
+        @test qc.parameters[:symmetry] == 8
+        ref = generate_ammann_beenker_projection(3.0)
+        @test num_sites(qc) == num_sites(ref)
+    end
+
+    @testset "fibonacci_projected(n_points) projection shortcut" begin
+        qc = fibonacci_projected(50)
+        @test qc isa QuasicrystalData{1,Float64}
+        @test qc.topology isa FibonacciLattice
+        @test qc.generation_method isa ProjectionMethod
+        ref = generate_fibonacci_projection(50)
+        @test num_sites(qc) == num_sites(ref)
+    end
+
+    @testset "shortcut return values match canonical generator field-by-field" begin
+        # Exercise the full QuasicrystalData payload (positions, params,
+        # generation_method) for each builder so that any future drift
+        # between builder and underlying generator is caught.
+        for (shortcut, ref) in (
+            (() -> fibonacci(3), () -> generate_fibonacci_substitution(3)),
+            (() -> penrose(2), () -> generate_penrose_substitution(2)),
+            (() -> ammann_beenker(2), () -> generate_ammann_beenker_substitution(2)),
+            (() -> penrose_projected(3.0), () -> generate_penrose_projection(3.0)),
+            (
+                () -> ammann_beenker_projected(3.0),
+                () -> generate_ammann_beenker_projection(3.0),
+            ),
+            (() -> fibonacci_projected(20), () -> generate_fibonacci_projection(20)),
+        )
+            qc = shortcut()
+            qc_ref = ref()
+            @test num_sites(qc) == num_sites(qc_ref)
+            @test typeof(qc.topology) === typeof(qc_ref.topology)
+            @test typeof(qc.generation_method) === typeof(qc_ref.generation_method)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ ENV["GKSwstype"] = "100"
 using QuasiCrystal, Test
 using LinearAlgebra
 using StaticArrays
-const dirs = ["model", "analysis"]
+const dirs = ["model", "analysis", "api"]
 
 @testset "tests" begin
     test_args = copy(ARGS)


### PR DESCRIPTION
## Summary
- Adds `src/api/builders.jl` with one-liner shortcuts: `penrose(n)`, `ammann_beenker(n)`, `fibonacci(n)` (substitution route, default `n` ships a usable point set) and `penrose_projected(r)`, `ammann_beenker_projected(r)`, `fibonacci_projected(n_points)` (cut-and-project route).
- Pure delegators around the existing `generate_*_substitution` / `generate_*_projection` family — no behavioural change to existing names. The `method` keyword on the substitution shortcuts accepts either an `AbstractSubstitutionAlgorithm` singleton or a fully-formed `SubstitutionMethod`.
- New test directory `test/api/` wired into `test/runtests.jl`; the new `test_builders.jl` exercises every shortcut, asserts default keyword values, verifies field-by-field agreement with the canonical generators, and confirms the bare-algorithm / wrapped-method paths agree.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` — all 23706 tests pass (was 23624; the 8 new builder testsets contribute the rest, including Aqua quality checks).
- [x] No `Project.toml` or `Manifest.toml` change.
- [x] Existing `generate_*` API is untouched.