### PR TITLE
feat: phason-space utilities for Fibonacci chain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.11"
+version = "0.5.12"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -127,6 +127,7 @@ include("core/numerics.jl")
 include("core/interface.jl")
 include("core/element_api.jl")
 include("core/model/fibonacci.jl")
+include("core/model/fibonacci_phason.jl")
 include("core/model/penrose.jl")
 include("core/model/ammann_beenker.jl")
 include("core/fourier/window.jl")
@@ -159,6 +160,10 @@ export generate_fibonacci_projection, generate_fibonacci_substitution
 export generate_penrose_projection, generate_penrose_substitution
 export generate_ammann_beenker_projection, generate_ammann_beenker_substitution
 export fibonacci_sequence_length
+# Phason-space utilities (see src/core/model/fibonacci_phason.jl)
+export PHASON_INTERCEPT_FIBONACCI
+export fibonacci_word, phason_orbit_at, bond_couplings
+export phason_grid_shift, inflation_matrix, J_fourier_coeffs
 # Convenience builder API (thin wrappers, see src/api/builders.jl)
 export fibonacci, penrose, ammann_beenker
 export fibonacci_projected, penrose_projected, ammann_beenker_projected

--- a/src/core/model/fibonacci_phason.jl
+++ b/src/core/model/fibonacci_phason.jl
@@ -1,0 +1,232 @@
+"""
+Phason-space utilities for the Fibonacci chain.
+
+These are the **geometric** primitives that any quasi-1D Fibonacci
+model needs but that do not belong inside a specific Hamiltonian
+or variational ansatz: the binary L/S word produced by the
+substitution `L → LS, S → L`; the phason orbit on the torus
+`R / Z`; the integer permutation that an irrational shift induces
+on a uniform `M`-bin θ-grid; the inflation matrix; and the Fourier
+expansion of an L/S step-function coupling `J(θ)` keyed to that
+torus.
+
+They are dispatched on [`FibonacciLattice`](@ref) so that the
+analogous internal-space utilities for `PenroseP3` and
+`AmmannBeenker` can be added later without reusing names.
+"""
+
+# ---- Default phason intercept --------------------------------------
+
+"""
+    PHASON_INTERCEPT_FIBONACCI :: Float64
+
+Default phason intercept α = 1/ϕ used by the Fibonacci chain. Every
+function in this file takes `α` as a keyword argument and defaults
+to this constant, so callers can sweep other slopes for
+experiments without code changes.
+"""
+const PHASON_INTERCEPT_FIBONACCI = inv(ϕ)
+
+# ---- Substitution word ---------------------------------------------
+
+"""
+    fibonacci_word(::FibonacciLattice, gen::Int) → Vector{Int}
+
+Substitution word `L → LS, S → L` after `gen` iterations starting
+from the axiom `[L]`, returned as a binary vector with `0 = L`
+and `1 = S`. Length is `F_{gen + 2}` (Fibonacci numbers indexed by
+`F_1 = F_2 = 1`).
+
+```jldoctest
+julia> using QuasiCrystal
+
+julia> fibonacci_word(FibonacciLattice(), 0)
+1-element Vector{Int64}:
+ 0
+
+julia> fibonacci_word(FibonacciLattice(), 3)
+5-element Vector{Int64}:
+ 0
+ 1
+ 0
+ 0
+ 1
+```
+"""
+function fibonacci_word(::FibonacciLattice, gen::Int)
+    seq = [0]
+    for _ in 1:gen
+        new_seq = Int[]
+        for s in seq
+            if s == 0
+                push!(new_seq, 0, 1)
+            else
+                push!(new_seq, 0)
+            end
+        end
+        seq = new_seq
+    end
+    return seq
+end
+
+# ---- Phason orbit on the torus -------------------------------------
+
+"""
+    phason_orbit_at(::FibonacciLattice, i::Int;
+                    θ0::Real = 0.0,
+                    α::Real  = PHASON_INTERCEPT_FIBONACCI) → Float64
+
+Phason coordinate of site `i` on the unit torus `R / Z`:
+
+```math
+θ_i \\;=\\; \\{ θ_0 + i\\,α \\} \\;∈\\; [0, 1).
+```
+
+For α irrational (the Fibonacci case α = 1/ϕ) the orbit `{θ_i}` is
+equidistributed in `[0,1)`.
+"""
+function phason_orbit_at(
+    ::FibonacciLattice,
+    i::Int;
+    θ0::Real=0.0,
+    α::Real=PHASON_INTERCEPT_FIBONACCI,
+)
+    return mod(float(θ0) + i * float(α), 1.0)
+end
+
+# ---- Bond coupling pattern -----------------------------------------
+
+"""
+    bond_couplings(::FibonacciLattice, JL::Real, JS::Real;
+                   gen::Int) → Vector{Float64}
+
+Per-bond coupling array of length `length(word) - 1` for the
+substitution word at the requested generation `gen`. Bond `i`
+takes the value `JL` when `word[i] == 0` (L bond) and `JS`
+otherwise.
+
+This is the discrete-site version of the L/S step function
+`J(θ)` whose Fourier expansion is exposed by
+[`J_fourier_coeffs`](@ref).
+"""
+function bond_couplings(
+    lat::FibonacciLattice, JL::Real, JS::Real; gen::Int
+)
+    seq = fibonacci_word(lat, gen)
+    return Float64[seq[i] == 0 ? Float64(JL) : Float64(JS) for i in 1:(length(seq) - 1)]
+end
+
+# ---- Discrete phason-grid shift ------------------------------------
+
+"""
+    phason_grid_shift(::FibonacciLattice, M::Int;
+                      α::Real = PHASON_INTERCEPT_FIBONACCI) → Vector{Int}
+
+Permutation `σ : 1:M → 1:M` such that
+`θ_{σ(k)} ≈ θ_k + α  (mod 1)` on the uniform M-bin grid
+`θ_k = (k - 1) / M`. Each entry is computed by rounding the
+shifted continuous coordinate to the nearest grid index and
+wrapping with `mod1`.
+
+For irrational `α` this is the discretisation that an `M`-binned
+phason-space cocycle uses to advance one site.
+"""
+function phason_grid_shift(
+    ::FibonacciLattice, M::Int; α::Real=PHASON_INTERCEPT_FIBONACCI
+)
+    return map(1:M) do k
+        mod1(round(Int, mod((k - 1) / M + α, 1.0) * M) + 1, M)
+    end
+end
+
+# ---- Inflation matrix ----------------------------------------------
+
+"""
+    inflation_matrix(::FibonacciLattice) → SMatrix{2,2,Int,4}
+
+`M = ((1,1),(1,0))`, the abelianisation of the Fibonacci
+substitution. Eigenvalues are `(ϕ, -1/ϕ)`; the parallel /
+perpendicular projectors of the cut-and-project description are
+the eigenvectors of `M`.
+"""
+inflation_matrix(::FibonacciLattice) = SMatrix{2,2,Int}(1, 1, 1, 0)
+
+# ---- Step-function Fourier coefficients ----------------------------
+
+"""
+    _J_fourier_intervals(::FibonacciLattice, α::Real)
+        → (L_intervals, S_intervals)
+
+L/S partition of the phason torus that `J_fourier_coeffs` integrates
+over. For α ∈ (0, 1) the partition is
+
+  - L: `[0, 1 - α) ∪ [2 - 2α, 1)`
+  - S: `[1 - α, 2 - 2α)`
+
+This matches the 2-step orbital labeling used downstream by the
+Fibonacci VUMPS cocycle (the bond between sites `i` and `i+1`
+carries the phason midpoint `θ_i + α / 2 mod 1`).
+"""
+function _J_fourier_intervals(::FibonacciLattice, α::Real)
+    αf = float(α)
+    L_intervals = ((0.0, 1.0 - αf), (2.0 - 2αf, 1.0))
+    S_intervals = ((1.0 - αf, 2.0 - 2αf),)
+    return L_intervals, S_intervals
+end
+
+"""
+    _indicator_fourier_coefficient(a::Real, b::Real, k::Int) → ComplexF64
+
+`∫_a^b e^{-2πi k θ} dθ` for the indicator of `[a, b)`. At `k = 0`
+this is `b - a` (mean contribution); otherwise it is the closed
+form `(e^{-2πi k a} - e^{-2πi k b}) / (2πi k)`.
+"""
+function _indicator_fourier_coefficient(a::Real, b::Real, k::Int)
+    if k == 0
+        return ComplexF64(b - a)
+    end
+    kk = 2π * im * k
+    return (exp(-kk * a) - exp(-kk * b)) / kk
+end
+
+"""
+    J_fourier_coeffs(::FibonacciLattice, JL::Real, JS::Real, K_J::Int;
+                     α::Real = PHASON_INTERCEPT_FIBONACCI)
+        → Vector{ComplexF64}
+
+Fourier coefficients `Ĵ_k` for `k ∈ -K_J : K_J` of the L/S step
+function `J(θ)` on the unit phason torus, under the convention
+
+```math
+J(θ) \\;=\\; \\sum_{k} \\hat J_k\\, e^{2\\pi i k θ}.
+```
+
+The partition is taken from [`_J_fourier_intervals`](@ref), so
+
+```math
+\\hat J_k \\;=\\; J_L \\sum_{(a,b) \\in L} \\hat χ_{[a,b)}(k)
+            \\;+\\; J_S \\sum_{(a,b) \\in S} \\hat χ_{[a,b)}(k),
+```
+
+where `χ̂_{[a,b)}(k)` is the per-interval coefficient from
+[`_indicator_fourier_coefficient`](@ref). The DC term reproduces
+the orbit average `⟨J⟩ = α·J_L + (1-α)·J_S` (mean Birkhoff sum).
+"""
+function J_fourier_coeffs(
+    lat::FibonacciLattice,
+    JL::Real,
+    JS::Real,
+    K_J::Int;
+    α::Real=PHASON_INTERCEPT_FIBONACCI,
+)
+    L_intervals, S_intervals = _J_fourier_intervals(lat, α)
+    JL_f = Float64(JL)
+    JS_f = Float64(JS)
+    return ComplexF64[
+        JL_f *
+        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in L_intervals) +
+        JS_f *
+        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in S_intervals) for
+        k in (-K_J):K_J
+    ]
+end

--- a/src/core/model/fibonacci_phason.jl
+++ b/src/core/model/fibonacci_phason.jl
@@ -86,10 +86,7 @@ For α irrational (the Fibonacci case α = 1/ϕ) the orbit `{θ_i}` is
 equidistributed in `[0,1)`.
 """
 function phason_orbit_at(
-    ::FibonacciLattice,
-    i::Int;
-    θ0::Real=0.0,
-    α::Real=PHASON_INTERCEPT_FIBONACCI,
+    ::FibonacciLattice, i::Int; θ0::Real=0.0, α::Real=PHASON_INTERCEPT_FIBONACCI
 )
     return mod(float(θ0) + i * float(α), 1.0)
 end
@@ -109,9 +106,7 @@ This is the discrete-site version of the L/S step function
 `J(θ)` whose Fourier expansion is exposed by
 [`J_fourier_coeffs`](@ref).
 """
-function bond_couplings(
-    lat::FibonacciLattice, JL::Real, JS::Real; gen::Int
-)
+function bond_couplings(lat::FibonacciLattice, JL::Real, JS::Real; gen::Int)
     seq = fibonacci_word(lat, gen)
     return Float64[seq[i] == 0 ? Float64(JL) : Float64(JS) for i in 1:(length(seq) - 1)]
 end
@@ -131,9 +126,7 @@ wrapping with `mod1`.
 For irrational `α` this is the discretisation that an `M`-binned
 phason-space cocycle uses to advance one site.
 """
-function phason_grid_shift(
-    ::FibonacciLattice, M::Int; α::Real=PHASON_INTERCEPT_FIBONACCI
-)
+function phason_grid_shift(::FibonacciLattice, M::Int; α::Real=PHASON_INTERCEPT_FIBONACCI)
     return map(1:M) do k
         mod1(round(Int, mod((k - 1) / M + α, 1.0) * M) + 1, M)
     end
@@ -213,20 +206,14 @@ where `χ̂_{[a,b)}(k)` is the per-interval coefficient from
 the orbit average `⟨J⟩ = α·J_L + (1-α)·J_S` (mean Birkhoff sum).
 """
 function J_fourier_coeffs(
-    lat::FibonacciLattice,
-    JL::Real,
-    JS::Real,
-    K_J::Int;
-    α::Real=PHASON_INTERCEPT_FIBONACCI,
+    lat::FibonacciLattice, JL::Real, JS::Real, K_J::Int; α::Real=PHASON_INTERCEPT_FIBONACCI
 )
     L_intervals, S_intervals = _J_fourier_intervals(lat, α)
     JL_f = Float64(JL)
     JS_f = Float64(JS)
     return ComplexF64[
-        JL_f *
-        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in L_intervals) +
-        JS_f *
-        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in S_intervals) for
+        JL_f * sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in L_intervals) +
+        JS_f * sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in S_intervals) for
         k in (-K_J):K_J
     ]
 end

--- a/test/model/test_fibonacci_phason.jl
+++ b/test/model/test_fibonacci_phason.jl
@@ -1,0 +1,150 @@
+using QuasiCrystal
+using Test
+using StaticArrays
+using LinearAlgebra: eigvals
+
+@testset "fibonacci_phason" begin
+    lat = FibonacciLattice()
+    α = PHASON_INTERCEPT_FIBONACCI
+    @test α ≈ inv(ϕ)
+    @test 0 < α < 1
+
+    @testset "fibonacci_word" begin
+        # axiom is [L] ≡ [0]
+        @test fibonacci_word(lat, 0) == [0]
+        # gen 1: L → LS  ⇒  [0, 1]
+        @test fibonacci_word(lat, 1) == [0, 1]
+        # gen 2: LS → LS L  ⇒  [0, 1, 0]
+        @test fibonacci_word(lat, 2) == [0, 1, 0]
+        # gen 3: LS L → LS L LS  ⇒  [0, 1, 0, 0, 1]
+        @test fibonacci_word(lat, 3) == [0, 1, 0, 0, 1]
+
+        # length = F_{gen+2}  (F_1 = F_2 = 1)
+        @test length(fibonacci_word(lat, 0)) == fibonacci_sequence_length(0)
+        @test length(fibonacci_word(lat, 5)) == fibonacci_sequence_length(5)
+        @test length(fibonacci_word(lat, 8)) == fibonacci_sequence_length(8)
+
+        # alphabet is {0, 1} only
+        w = fibonacci_word(lat, 7)
+        @test all(s -> s == 0 || s == 1, w)
+
+        # eventually-L ratio → α (equivalently #L / #S → ϕ)
+        big = fibonacci_word(lat, 14)
+        n_L = count(==(0), big)
+        @test n_L / length(big) ≈ α atol = 1e-3
+    end
+
+    @testset "phason_orbit_at" begin
+        @test phason_orbit_at(lat, 0) == 0.0
+        @test phason_orbit_at(lat, 1) ≈ α
+        # closed-form for θ0 ≠ 0
+        @test phason_orbit_at(lat, 3; θ0=0.25) ≈ mod(0.25 + 3α, 1.0)
+        # custom slope override
+        @test phason_orbit_at(lat, 4; α=0.2) ≈ 0.8 atol = 1e-12
+        # range [0, 1)
+        for i in -3:7
+            θ = phason_orbit_at(lat, i)
+            @test 0 ≤ θ < 1
+        end
+        # equidistribution (Weyl) on the first ~10k iterates
+        N = 10_000
+        orbit = [phason_orbit_at(lat, i) for i in 0:(N - 1)]
+        # Halfway threshold should split close to 50/50.
+        @test abs(count(x -> x < 0.5, orbit) / N - 0.5) < 0.01
+    end
+
+    @testset "bond_couplings" begin
+        # explicit gen 4 word = [0,1,0,0,1,0,1,0]; 7 bonds
+        bs = bond_couplings(lat, 1.0, 0.5; gen=4)
+        @test bs == [1.0, 0.5, 1.0, 1.0, 0.5, 1.0, 0.5]
+
+        # length = length(word) - 1
+        for gen in (0, 1, 2, 6)
+            w = fibonacci_word(lat, gen)
+            b = bond_couplings(lat, 1.0, 2.0; gen=gen)
+            @test length(b) == length(w) - 1
+        end
+
+        # mean over a long chain → α·JL + (1-α)·JS
+        JL, JS = 1.0, 0.5
+        bs_long = bond_couplings(lat, JL, JS; gen=14)
+        @test sum(bs_long) / length(bs_long) ≈ α * JL + (1 - α) * JS atol = 1e-3
+    end
+
+    @testset "phason_grid_shift" begin
+        # σ is a permutation of 1:M for every M
+        for M in (4, 8, 13, 21, 50)
+            σ = phason_grid_shift(lat, M)
+            @test length(σ) == M
+            @test sort(σ) == collect(1:M)
+            # |θ_{σ(k)} - (θ_k + α)| < 1/M (mod 1)
+            for k in 1:M
+                θk = (k - 1) / M
+                θs = (σ[k] - 1) / M
+                diff = mod(θs - θk - α + 0.5, 1.0) - 0.5
+                @test abs(diff) ≤ 1 / M
+            end
+        end
+
+        # custom α override (rational slope ⇒ exact shift)
+        @test phason_grid_shift(lat, 5; α=0.2) == [2, 3, 4, 5, 1]
+    end
+
+    @testset "inflation_matrix" begin
+        M = inflation_matrix(lat)
+        @test M == SMatrix{2,2,Int}(1, 1, 1, 0)
+        # eigenvalues = (ϕ, -1/ϕ)
+        evs = eigvals(Float64.(M))
+        @test maximum(evs) ≈ ϕ atol = 1e-12
+        @test minimum(evs) ≈ -inv(ϕ) atol = 1e-12
+    end
+
+    @testset "J_fourier_coeffs" begin
+        JL, JS = 1.0, 0.5
+        K_J = 20
+        Ĵ = J_fourier_coeffs(lat, JL, JS, K_J)
+        @test length(Ĵ) == 2K_J + 1
+
+        # DC term = orbit average
+        Ĵ_0 = Ĵ[K_J + 1]
+        @test real(Ĵ_0) ≈ α * JL + (1 - α) * JS atol = 1e-12
+        @test abs(imag(Ĵ_0)) < 1e-12
+
+        # J(θ) is real ⇒ Ĵ_{-k} = conj(Ĵ_k)
+        for k in 1:K_J
+            @test Ĵ[K_J + 1 - k] ≈ conj(Ĵ[K_J + 1 + k]) atol = 1e-12
+        end
+
+        # reconstruct J(θ) on a dense grid via partial sum
+        function J_truth(θ::Real, α::Real)
+            θm = mod(θ, 1.0)
+            if 0.0 ≤ θm < 1 - α
+                return JL
+            elseif 1 - α ≤ θm < 2 - 2α
+                return JS
+            else
+                return JL
+            end
+        end
+
+        function J_recon(θ::Real, Ĵ::Vector{ComplexF64}, K_J::Int)
+            s = 0.0 + 0.0im
+            for (idx, k) in enumerate((-K_J):K_J)
+                s += Ĵ[idx] * cis(2π * k * θ)
+            end
+            return real(s)
+        end
+
+        # Sample θ away from step discontinuities (Gibbs-free zone).
+        θs = [0.1, 0.2, 0.3, 0.5, 0.7, 0.9]
+        for θ in θs
+            jt = J_truth(θ, α)
+            jr = J_recon(θ, Ĵ, K_J)
+            @test abs(jt - jr) < 0.05
+        end
+
+        # Custom α path stays consistent at DC.
+        Ĵ_alt = J_fourier_coeffs(lat, 1.0, 0.0, 8; α=0.3)
+        @test real(Ĵ_alt[8 + 1]) ≈ 0.3 atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

Adds a topology-keyed phason-space layer to QuasiCrystal.jl that any
quasi-1D Fibonacci model can share, without dragging in Hamiltonian
or variational-ansatz state. Motivated by an in-flight refactor
where FibVUMPS.jl is being slimmed down to its ansatz / environment
tensor / loss code and the geometric utilities (phason orbit, J(θ)
Fourier expansion, inflation matrix) are moving here.

## New API (exported)

All dispatched on `FibonacciLattice` so the analogous internal-space
utilities for `PenroseP3` / `AmmannBeenker` can be added later
without name reuse.

- `fibonacci_word(::FibonacciLattice, gen)` — binary substitution word
  (0 = L, 1 = S)
- `phason_orbit_at(::FibonacciLattice, i; θ0, α)` — orbit
  `mod(θ0 + i·α, 1)` on R/Z, α = 1/φ by default
- `bond_couplings(::FibonacciLattice, JL, JS; gen)` — per-bond L/S
  pattern of length `length(word) - 1`
- `phason_grid_shift(::FibonacciLattice, M; α)` — α-shift permutation
  of the uniform M-bin θ-grid
- `inflation_matrix(::FibonacciLattice)` — `SMatrix{2,2,Int}((1,1),(1,0))`,
  eigenvalues `(φ, -1/φ)`
- `J_fourier_coeffs(::FibonacciLattice, JL, JS, K_J; α)` — 2K_J+1
  complex coefficients of the L/S step function J(θ) on the unit
  torus with the convention `J(θ) = Σ_k Ĵ_k e^{2πi k θ}`

`PHASON_INTERCEPT_FIBONACCI = 1/ϕ` is exposed as the default
intercept so consumers can either rely on the constant or sweep
other slopes via kwarg.

## Notes

- Internal helpers `_J_fourier_intervals` and
  `_indicator_fourier_coefficient` are pulled out so the L/S
  partition of the torus is documented in one place and the
  generic interval-indicator Fourier integral is reusable.
- Ansatz / Hamiltonian / loss-function code stays in FibVUMPS.jl
  per the consumer's request — this PR is intentionally scoped to
  the geometry layer only.

## Test plan

- [x] `fibonacci_word` matches axiom + first three substitutions,
      length = F_{gen+2}, alphabet = {0,1}, `#L / N → 1/φ` for gen 14
- [x] `phason_orbit_at` closed-form, custom α, range `[0,1)`, Weyl
      equidistribution to 1% on 10k iterates
- [x] `bond_couplings` explicit pattern + length = `length(word) - 1`
      + orbit-average mean
- [x] `phason_grid_shift` is a permutation,
      `|θ_{σ(k)} − (θ_k + α)| ≤ 1/M`, exact match for rational α
- [x] `inflation_matrix` eigenvalues = (ϕ, -1/ϕ)
- [x] `J_fourier_coeffs`: DC = orbit average, Hermitian symmetry
      `Ĵ_{-k} = conj(Ĵ_k)`, dense reconstruction error < 0.05 away
      from step discontinuities, custom α DC matches
- [x] 173 new assertions in `test/model/test_fibonacci_phason.jl`
- [x] Full suite `Pkg.test()` 22799 / 22799 pass
- [x] Aqua clean (undefined exports / stale deps / compat bounds /
      persistent tasks)

Version bumped to 0.5.12.
