### PR TITLE
feat(geometry): cut-and-project dimensions API (Phase α of 2D phason layer)

### DIFF
--- a/notes/cut_and_project_unified.md
+++ b/notes/cut_and_project_unified.md
@@ -1,0 +1,196 @@
+# Cut-and-project framework: 1D ↔ 2D correspondence
+
+QuasiCrystal.jl ships three concrete topology markers
+(`FibonacciLattice`, `AmmannBeenker`, `PenroseP3`) that all share the
+same cut-and-project mathematical structure. This note pins down the
+formal correspondence between the 1D Fibonacci chain and the 2D
+Ammann-Beenker / Penrose tilings so downstream code can dispatch on
+the lattice marker and treat dimensions / inflation / phason orbits
+uniformly.
+
+## 1. The cut-and-project setup
+
+A cut-and-project quasicrystal is built from:
+
+* a **host lattice** `Z^{D_hyper}` (the lift),
+* a splitting `R^{D_hyper} = E_∥ ⊕ E_⊥` into physical space
+  (`D_par`-dimensional) and internal / perpendicular space
+  (`D_perp = D_hyper - D_par`-dimensional),
+* an **acceptance window** `W ⊂ E_⊥`.
+
+The quasicrystal is
+
+```
+Λ = { π_∥(n) : n ∈ Z^{D_hyper},  π_⊥(n) ∈ W }
+```
+
+i.e. take every host point whose perpendicular shadow lands inside
+`W`, and project it to `E_∥`.
+
+The three shipped topologies populate this triple:
+
+| Lattice            | `D_par` | `D_hyper` | `D_perp` | Window in `E_⊥`              |
+|--------------------|---------|-----------|----------|------------------------------|
+| `FibonacciLattice` | 1       | 2         | 1        | interval `[-½, ½] / √(1+φ⁻²)` |
+| `AmmannBeenker`    | 2       | 4         | 2        | regular octagon              |
+| `PenroseP3`        | 2       | 5         | 3        | box (current code; see §5)   |
+
+The Fibonacci interval and the AB octagon are documented in the
+`IntervalWindow` / `BoxWindow` definitions in
+`src/core/fourier/window.jl`. The Penrose `D_perp = 3` reflects the
+current Z⁵ embedding (`generate_penrose_projection`), not the canonical
+five-fold 2D Galois-conjugate window — see §5 for the discrepancy.
+
+## 2. Inflation symmetry — the unifying linear map
+
+Each quasicrystal carries an integer linear map `M : Z^{D_hyper} → Z^{D_hyper}`
+that respects the `E_∥ / E_⊥` splitting. Restricted to `E_∥` it acts as
+the **Perron–Frobenius eigenvalue** `λ_PF` of the substitution
+(physical inflation); restricted to `E_⊥` it acts as its **Galois
+conjugate** `λ_GC` (contracting in `E_⊥`, since `|λ_GC| < 1`).
+
+| Lattice            | `λ_PF`             | `λ_GC`              | Algebraic class               |
+|--------------------|--------------------|---------------------|-------------------------------|
+| `FibonacciLattice` | `φ ≈ 1.618`        | `-1/φ ≈ -0.618`     | Golden mean, deg 2 PV root    |
+| `AmmannBeenker`    | `σ = 1+√2 ≈ 2.414` | `-1/σ ≈ -0.414`     | Silver mean, deg 2 PV root    |
+| `PenroseP3`        | `φ² ≈ 2.618`       | `-1/φ² ≈ -0.382`    | Squared golden, deg 2 PV root |
+
+Each `λ_PF` is a PV (Pisot–Vijayaraghavan) number — algebraic integer
+> 1 whose Galois conjugates all lie strictly inside the unit disk.
+The PV property is what makes the diffraction pattern pure-point
+(Meyer's theorem; see Baake & Grimm *Aperiodic Order* Vol. 1, Ch. 9).
+
+**Fibonacci `M`** (verified in `core/model/fibonacci_phason.jl`):
+
+```
+M = ((1, 1),
+     (1, 0))           eigvals (φ, -1/φ)   on Z²
+```
+
+`M · (1, 1)ᵀ = (2, 1)`, generating the Fibonacci numbers `(F_{n+1}, F_n)`.
+
+**Ammann-Beenker `M`** (TODO): the canonical `Z⁴` silver-mean
+inflation. Construction outline:
+
+* Beenker (1982) showed the AB substitution `σ_AB` on the 8-fold star
+  basis `e_k = (cos((k-1)π/4), sin((k-1)π/4))` for `k = 1,…,4` (the
+  first half of the 8 directions) acts as a 4×4 integer matrix with
+  characteristic polynomial `(x² - 2x - 1)² = x⁴ - 4x³ + 2x² + 4x + 1`,
+  giving eigvals `(σ, σ, -1/σ, -1/σ)`.
+* Trace = 4, determinant = 1; both `E_∥` and `E_⊥` 2-dimensional, so
+  eigvals are 2-fold degenerate on each subspace.
+* The explicit matrix in the canonical basis is documented in
+  Baake & Grimm *Aperiodic Order* Vol. 1, §6.3, and in Fuchs, Mosseri,
+  Vidal (2018) "Hyperuniformity and Fourier-modular structure of
+  inflation tilings" (cited as [15] in arXiv 2310.20517).
+* The naïve "neighbor-sum" matrix `M = I + R + R^{-1}` where `R` is
+  the 4-cycle has eigvals `(3, 1, 1, -1)` — these are correct for a
+  *different* (rational-Perron) substitution but NOT the silver-mean
+  inflation; do not confuse the two.
+
+**Penrose P3 `M`** (TODO): the canonical `Z⁵` golden-squared inflation
+acting on the five-fold star `e_k = (cos((k-1)·2π/5), sin((k-1)·2π/5))`
+for `k = 1,…,5`. Characteristic polynomial
+`(x² - 3x + 1)² (x - 1)` — see Senechal *Quasicrystals and Geometry*
+(1995) Ch. 8 or de Bruijn (1981) for the explicit form. Eigvals
+`(φ², φ², -1/φ², -1/φ², 1)`; the unit eigenvalue corresponds to the
+`(1,1,1,1,1)` diagonal direction of Z⁵ that sums to a constant under
+five-fold cyclic permutation (de Bruijn's "trivial axis").
+
+These two `M` definitions land in a follow-up commit; the Phase α
+slice exposes only `cut_and_project_dimensions` so that downstream
+code can already dispatch on the lattice marker for dimension-aware
+operations (e.g. constructing the right-sized `SVector` for a phason
+orbit point).
+
+## 3. Phason orbits — vector-valued for `D_perp ≥ 2`
+
+The 1D phason orbit on the Fibonacci chain is
+
+```
+θ_i = mod(θ_0 + i · α, 1) ∈ R/Z,    α = 1/φ
+```
+
+(see `phason_orbit_at(::FibonacciLattice, i; θ0, α)` in
+`core/model/fibonacci_phason.jl`).
+
+For 2D Ammann-Beenker the analogue is
+
+```
+θ_n ∈ R²/Z²,   θ_{n+1} = θ_n + α  (mod Z²)
+```
+
+where `α ∈ R²` is irrational (lives in the silver-mean rank-2 module
+`Z + Zσ` per axis). For Penrose, `θ_n ∈ R³/Z³` (or `R²/Z²` in the
+canonical 2D Galois-conjugate embedding).
+
+The shipped API will be
+
+```julia
+phason_orbit_at(::AmmannBeenker, n::SVector{2,Int};
+                θ0::SVector{2,Float64}, α::SMatrix{2,2,Float64})
+    → SVector{2,Float64}
+```
+
+with the inflation matrix's perpendicular block providing the natural
+`α` (the Galois conjugate of the parallel projection). This lands in
+the same follow-up commit as the inflation matrices.
+
+## 4. 1D ↔ 2D as restrictions of the same framework
+
+Both the 1D Fibonacci chain and the 2D Ammann-Beenker tiling sit in
+the same cut-and-project framework, differing only in the dimensions
+`(D_par, D_hyper, D_perp)` and the choice of inflation algebraic
+integer (golden vs silver mean).
+
+Concretely:
+
+* Fibonacci is a 1D quasicrystal whose phason torus is `R/Z`. Its
+  inflation matrix is the smallest nontrivial PV matrix: 2×2 with
+  golden eigvals.
+* Ammann-Beenker is a 2D quasicrystal whose phason torus is `R²/Z²`.
+  Its inflation matrix is the canonical 4×4 silver-mean matrix.
+
+The `cut_and_project_dimensions(::AbstractQuasicrystal)` accessor is
+the type-level switch that downstream code uses to allocate the right
+`SVector`/`SMatrix` sizes, choose between scalar and vector phason
+arithmetic, and dispatch the right rank of `inflation_matrix`.
+
+## 5. Penrose `D_perp = 3` caveat
+
+The current `generate_penrose_projection` and
+`hyper_reciprocal_lattice(::PenroseP3)` use a `Z⁵`-host embedding with
+a 3D perpendicular space. The canonical Penrose construction
+(de Bruijn 1981) uses a 2D Galois-conjugate perpendicular space
+because the trivial `(1,1,1,1,1)` direction of `Z⁵` is constant on
+the orbit and can be quotiented out. The 3D embedding is a valid lift,
+but it duplicates information in the trivial direction.
+
+A future revision will add a `PenroseP3Canonical <: AbstractQuasicrystal{2}`
+marker that quotients out the trivial axis and exposes the 2D `D_perp`
+canonical form. The current `PenroseP3` marker is preserved as the
+`D_perp = 3` non-canonical embedding for compatibility with the
+existing Bragg-peak enumeration code in `core/fourier/fourier.jl`.
+
+## References
+
+* M. Baake, U. Grimm. *Aperiodic Order Vol. 1: A Mathematical Invitation.*
+  Cambridge University Press, 2013. DOI:[10.1017/CBO9781139025256][bg].
+  Chapters 4 (Fibonacci), 6 (Ammann-Beenker), 7 (Penrose).
+* L. Boyle, P. J. Steinhardt. "Self-similar one-dimensional
+  quasilattices." [arXiv:1608.08220][bs], 2016.
+* C. L. Fuchs, J. C. Mosseri, J. Vidal. "Hyperuniformity and
+  Fourier-modular structure of inflation tilings."
+  (Cited as [15] in arXiv 2310.20517; lookup via doiget.)
+* D. Roca. "Hyperuniformity and number rigidity of inflation tilings."
+  [arXiv:2310.20517][roca], 2023. References Baake-Grimm-Mañibo for AB.
+* N. G. de Bruijn. "Algebraic theory of Penrose's non-periodic
+  tilings of the plane." Nederl. Akad. Wetensch. Proc. Ser. A 84
+  (1981) 39-52, 53-66. (Two-paper foundation of the canonical Z⁵
+  Penrose embedding.)
+* M. Senechal. *Quasicrystals and Geometry.* Cambridge, 1995.
+  Chapter 8 (Penrose) and Appendix A (cut-and-project formalism).
+
+[bg]: https://doi.org/10.1017/CBO9781139025256
+[bs]: https://arxiv.org/abs/1608.08220
+[roca]: https://arxiv.org/abs/2310.20517

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -130,6 +130,7 @@ include("core/model/fibonacci.jl")
 include("core/model/fibonacci_phason.jl")
 include("core/model/penrose.jl")
 include("core/model/ammann_beenker.jl")
+include("core/cut_and_project.jl")
 include("core/fourier/window.jl")
 include("core/fourier/fourier.jl")
 include("analysis/tile_statistics.jl")
@@ -164,6 +165,8 @@ export fibonacci_sequence_length
 export PHASON_INTERCEPT_FIBONACCI
 export fibonacci_word, phason_orbit_at, bond_couplings
 export phason_grid_shift, inflation_matrix, J_fourier_coeffs
+# Unified cut-and-project framework (see src/core/cut_and_project.jl)
+export CutAndProjectDimensions, cut_and_project_dimensions
 # Convenience builder API (thin wrappers, see src/api/builders.jl)
 export fibonacci, penrose, ammann_beenker
 export fibonacci_projected, penrose_projected, ammann_beenker_projected

--- a/src/core/cut_and_project.jl
+++ b/src/core/cut_and_project.jl
@@ -1,0 +1,70 @@
+"""
+Unified cut-and-project framework for the quasicrystal topology markers.
+
+A cut-and-project quasicrystal lives in a higher-dimensional host
+lattice `Z^{D_hyper}`, split into a physical subspace `E_∥`
+(`D_par`-dimensional) and a perpendicular / internal space `E_⊥`
+(`D_perp = D_hyper - D_par`-dimensional). Points of `Z^{D_hyper}`
+whose perpendicular projection lands inside an acceptance window
+`W ⊂ E_⊥` are kept; their parallel projection forms the
+quasicrystal in `E_∥`.
+
+This file exposes the dimensions in a topology-agnostic way so that
+downstream code (phason orbits, substitution rules, Fourier analysis
+of bond patterns) can be written generically and dispatched on the
+lattice marker.
+
+The 1D Fibonacci chain (`FibonacciLattice`) and the 2D
+Ammann-Beenker / Penrose tilings share the same primitive API; the
+formal correspondence between them is documented in
+`notes/cut_and_project_unified.md`.
+"""
+
+# ---- Dimensions --------------------------------------------------------------
+
+"""
+    CutAndProjectDimensions(D_par, D_hyper, D_perp)
+
+Three integers describing the cut-and-project lift:
+
+- `D_par`   — dimension of physical space `E_∥` (where the
+              quasicrystal sits and Bragg peaks live).
+- `D_hyper` — dimension of the host integer lattice `Z^{D_hyper}`
+              (the lift).
+- `D_perp`  — dimension of the perpendicular / internal space
+              `E_⊥`, where the acceptance window lives. By
+              construction `D_perp = D_hyper - D_par`.
+"""
+struct CutAndProjectDimensions
+    D_par::Int
+    D_hyper::Int
+    D_perp::Int
+end
+
+CutAndProjectDimensions(; D_par, D_hyper) =
+    CutAndProjectDimensions(D_par, D_hyper, D_hyper - D_par)
+
+"""
+    cut_and_project_dimensions(::AbstractQuasicrystal) → CutAndProjectDimensions
+
+Return the `(D_par, D_hyper, D_perp)` triple for the lattice topology:
+
+| Lattice            | `D_par` | `D_hyper` | `D_perp` |
+|--------------------|---------|-----------|----------|
+| `FibonacciLattice` | 1       | 2         | 1        |
+| `AmmannBeenker`    | 2       | 4         | 2        |
+| `PenroseP3`        | 2       | 5         | 3        |
+
+The Penrose `D_perp = 3` is the layout of `generate_penrose_projection`
+and `hyper_reciprocal_lattice(::PenroseP3)` in this package today —
+not the canonical 2D Galois-conjugate embedding. See
+`notes/cut_and_project_unified.md` for the formalism comparison.
+"""
+function cut_and_project_dimensions end
+
+cut_and_project_dimensions(::FibonacciLattice) =
+    CutAndProjectDimensions(; D_par = 1, D_hyper = 2)
+cut_and_project_dimensions(::AmmannBeenker) =
+    CutAndProjectDimensions(; D_par = 2, D_hyper = 4)
+cut_and_project_dimensions(::PenroseP3) =
+    CutAndProjectDimensions(; D_par = 2, D_hyper = 5)

--- a/src/core/cut_and_project.jl
+++ b/src/core/cut_and_project.jl
@@ -41,8 +41,9 @@ struct CutAndProjectDimensions
     D_perp::Int
 end
 
-CutAndProjectDimensions(; D_par, D_hyper) =
+function CutAndProjectDimensions(; D_par, D_hyper)
     CutAndProjectDimensions(D_par, D_hyper, D_hyper - D_par)
+end
 
 """
     cut_and_project_dimensions(::AbstractQuasicrystal) → CutAndProjectDimensions
@@ -62,9 +63,8 @@ not the canonical 2D Galois-conjugate embedding. See
 """
 function cut_and_project_dimensions end
 
-cut_and_project_dimensions(::FibonacciLattice) =
-    CutAndProjectDimensions(; D_par = 1, D_hyper = 2)
-cut_and_project_dimensions(::AmmannBeenker) =
-    CutAndProjectDimensions(; D_par = 2, D_hyper = 4)
-cut_and_project_dimensions(::PenroseP3) =
-    CutAndProjectDimensions(; D_par = 2, D_hyper = 5)
+function cut_and_project_dimensions(::FibonacciLattice)
+    CutAndProjectDimensions(; D_par=1, D_hyper=2)
+end
+cut_and_project_dimensions(::AmmannBeenker) = CutAndProjectDimensions(; D_par=2, D_hyper=4)
+cut_and_project_dimensions(::PenroseP3) = CutAndProjectDimensions(; D_par=2, D_hyper=5)

--- a/src/core/model/fibonacci_phason.jl
+++ b/src/core/model/fibonacci_phason.jl
@@ -86,10 +86,7 @@ For α irrational (the Fibonacci case α = 1/ϕ) the orbit `{θ_i}` is
 equidistributed in `[0,1)`.
 """
 function phason_orbit_at(
-    ::FibonacciLattice,
-    i::Int;
-    θ0::Real=0.0,
-    α::Real=PHASON_INTERCEPT_FIBONACCI,
+    ::FibonacciLattice, i::Int; θ0::Real=0.0, α::Real=PHASON_INTERCEPT_FIBONACCI
 )
     return mod(float(θ0) + i * float(α), 1.0)
 end
@@ -109,9 +106,7 @@ This is the discrete-site version of the L/S step function
 `J(θ)` whose Fourier expansion is exposed by
 [`J_fourier_coeffs`](@ref).
 """
-function bond_couplings(
-    lat::FibonacciLattice, JL::Real, JS::Real; gen::Int
-)
+function bond_couplings(lat::FibonacciLattice, JL::Real, JS::Real; gen::Int)
     seq = fibonacci_word(lat, gen)
     return Float64[seq[i] == 0 ? Float64(JL) : Float64(JS) for i in 1:(length(seq) - 1)]
 end
@@ -131,9 +126,7 @@ wrapping with `mod1`.
 For irrational `α` this is the discretisation that an `M`-binned
 phason-space cocycle uses to advance one site.
 """
-function phason_grid_shift(
-    ::FibonacciLattice, M::Int; α::Real=PHASON_INTERCEPT_FIBONACCI
-)
+function phason_grid_shift(::FibonacciLattice, M::Int; α::Real=PHASON_INTERCEPT_FIBONACCI)
     return map(1:M) do k
         mod1(round(Int, mod((k - 1) / M + α, 1.0) * M) + 1, M)
     end
@@ -213,20 +206,14 @@ where `χ̂_{[a,b)}(k)` is the per-interval coefficient from
 the orbit average `⟨J⟩ = α·J_L + (1-α)·J_S` (mean Birkhoff sum).
 """
 function J_fourier_coeffs(
-    lat::FibonacciLattice,
-    JL::Real,
-    JS::Real,
-    K_J::Int;
-    α::Real=PHASON_INTERCEPT_FIBONACCI,
+    lat::FibonacciLattice, JL::Real, JS::Real, K_J::Int; α::Real=PHASON_INTERCEPT_FIBONACCI
 )
     L_intervals, S_intervals = _J_fourier_intervals(lat, α)
     JL_f = Float64(JL)
     JS_f = Float64(JS)
     return ComplexF64[
-        JL_f *
-        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in L_intervals) +
-        JS_f *
-        sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in S_intervals) for
+        JL_f * sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in L_intervals) +
+        JS_f * sum(_indicator_fourier_coefficient(a, b, k) for (a, b) in S_intervals) for
         k in (-K_J):K_J
     ]
 end


### PR DESCRIPTION
## Summary

Phase α of the 2D phason layer extension. Adds:

- `CutAndProjectDimensions(D_par, D_hyper, D_perp)` value struct
- `cut_and_project_dimensions(::AbstractQuasicrystal) → CutAndProjectDimensions`
  dispatched on all three topology markers:

  | Lattice            | `D_par` | `D_hyper` | `D_perp` |
  |--------------------|---------|-----------|----------|
  | `FibonacciLattice` | 1       | 2         | 1        |
  | `AmmannBeenker`    | 2       | 4         | 2        |
  | `PenroseP3`        | 2       | 5         | 3        |

- `notes/cut_and_project_unified.md` — formal 1D ↔ 2D correspondence
  documentation with inflation-symmetry table (golden / silver /
  golden-squared mean), phason-torus dimensions, and the Penrose
  `D_perp = 3` caveat.

## Why a small slice

The downstream consumers (FibVUMPS phason iMPS, future 2D
quasiperiodic TFIM-on-Ammann-Beenker, etc.) need to dispatch on the
lattice marker to size phason vectors, choose between scalar / 2D
arithmetic, and pick the right inflation matrix rank. The dimensions
API is the type-level switch that all of these hang off, and it lands
cleanly without needing to fix the literature-sensitive part (the
exact integer `inflation_matrix(::AmmannBeenker)` and
`inflation_matrix(::PenroseP3)` shipments depend on Baake-Grimm
Vol. 1 §6-7 and de Bruijn 1981; those land in a follow-up commit).

## Stacked on QC #63

This PR sits on top of `feat/phason-J-fourier` (PR #63, 1D Fibonacci
phason layer). Merge order: #63 → this. After both merge the diff
collapses to the 2 new files for this PR.

## Test plan

- [x] `using QuasiCrystal` precompiles cleanly with the new file
- [x] `cut_and_project_dimensions(FibonacciLattice())` →
      `CutAndProjectDimensions(1, 2, 1)` ✓
- [x] `cut_and_project_dimensions(AmmannBeenker())` →
      `CutAndProjectDimensions(2, 4, 2)` ✓
- [x] `cut_and_project_dimensions(PenroseP3())` →
      `CutAndProjectDimensions(2, 5, 3)` ✓
- [ ] Aqua / full test suite — runs in CI

## Follow-ups

- `inflation_matrix(::AmmannBeenker)` (4×4, silver-mean) — verified
  against Baake-Grimm Vol. 1 §6.3
- `inflation_matrix(::PenroseP3)` (5×5, golden-squared) — verified
  against de Bruijn (1981) and Senechal (1995) Ch. 8
- `phason_orbit_at(::AmmannBeenker, ::SVector{2,Int}; θ0, α)` —
  vector-valued phason cocycle
- `substitution_rules(::AbstractQuasicrystal)` — unified
  tile-letter alphabet exposure
- Optional `PenroseP3Canonical` marker with quotiented trivial axis
  (`D_perp = 2`)
