### PR TITLE
feat: phason_bond_type(::FibonacciLattice, θ) L/S tile classifier

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuasiCrystal"
 uuid = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
-version = "0.5.12"
+version = "0.5.13"
 authors = ["sotashimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QuasiCrystal.jl
+++ b/src/QuasiCrystal.jl
@@ -163,7 +163,7 @@ export generate_ammann_beenker_projection, generate_ammann_beenker_substitution
 export fibonacci_sequence_length
 # Phason-space utilities (see src/core/model/fibonacci_phason.jl)
 export PHASON_INTERCEPT_FIBONACCI
-export fibonacci_word, phason_orbit_at, bond_couplings
+export fibonacci_word, phason_orbit_at, phason_bond_type, bond_couplings
 export phason_grid_shift, inflation_matrix, J_fourier_coeffs
 # Unified cut-and-project framework (see src/core/cut_and_project.jl)
 export CutAndProjectDimensions, cut_and_project_dimensions

--- a/src/core/model/fibonacci_phason.jl
+++ b/src/core/model/fibonacci_phason.jl
@@ -116,9 +116,7 @@ When applied along the phason orbit `θ_i = {θ_0 + i α}` for
 `phason_bond_type` and `J_fourier_coeffs` operate on the same step
 function `J(θ)`.
 """
-function phason_bond_type(
-    ::FibonacciLattice, θ::Real; α::Real=PHASON_INTERCEPT_FIBONACCI
-)
+function phason_bond_type(::FibonacciLattice, θ::Real; α::Real=PHASON_INTERCEPT_FIBONACCI)
     αf = float(α)
     θ_next = mod(float(θ) + αf, 1.0)
     return θ_next ≥ 1.0 - αf ? :L : :S

--- a/src/core/model/fibonacci_phason.jl
+++ b/src/core/model/fibonacci_phason.jl
@@ -91,6 +91,39 @@ function phason_orbit_at(
     return mod(float(θ0) + i * float(α), 1.0)
 end
 
+# ---- Bond tile classification on the phason torus ------------------
+
+"""
+    phason_bond_type(::FibonacciLattice, θ::Real;
+                     α::Real = PHASON_INTERCEPT_FIBONACCI) → Symbol
+
+Tile type (`:L` or `:S`) of the bond extending to the right of a site at
+phason coordinate `θ` on the unit torus `R / Z`. The rule is
+
+```math
+\\mathrm{bond}(θ) \\;=\\; :L \\quad\\Longleftrightarrow\\quad
+\\bigl\\{ θ + α \\bigr\\} \\;\\ge\\; 1 - α,
+```
+
+equivalently `θ ∈ [0, 1-α) ∪ [2-2α, 1)` after reducing mod 1. The
+complementary window `[1-α, 2-2α)` yields `:S`.
+
+When applied along the phason orbit `θ_i = {θ_0 + i α}` for
+`i = 0, 1, …`, the resulting `:L`/`:S` sequence reproduces
+[`fibonacci_word`](@ref) entry-for-entry (`0 = :L`, `1 = :S`) at
+`θ_0 = 0`. The partition coincides with the L/S windows used by
+[`J_fourier_coeffs`](@ref) (cf. [`_J_fourier_intervals`](@ref)), so
+`phason_bond_type` and `J_fourier_coeffs` operate on the same step
+function `J(θ)`.
+"""
+function phason_bond_type(
+    ::FibonacciLattice, θ::Real; α::Real=PHASON_INTERCEPT_FIBONACCI
+)
+    αf = float(α)
+    θ_next = mod(float(θ) + αf, 1.0)
+    return θ_next ≥ 1.0 - αf ? :L : :S
+end
+
 # ---- Bond coupling pattern -----------------------------------------
 
 """

--- a/test/model/test_fibonacci_phason.jl
+++ b/test/model/test_fibonacci_phason.jl
@@ -53,6 +53,55 @@ using LinearAlgebra: eigvals
         @test abs(count(x -> x < 0.5, orbit) / N - 0.5) < 0.01
     end
 
+    @testset "phason_bond_type" begin
+        # Single-θ sanity for α = 1/ϕ ≈ 0.618: L windows ≈ [0, 0.382) ∪ [0.764, 1).
+        @test phason_bond_type(lat, 0.0) === :L
+        @test phason_bond_type(lat, 0.3) === :L
+        @test phason_bond_type(lat, 0.5) === :S
+        @test phason_bond_type(lat, 0.9) === :L
+
+        # Applied along the phason orbit at θ0 = 0 it reproduces the
+        # Fibonacci substitution word entry-for-entry (0 = :L, 1 = :S).
+        for gen in (3, 6, 9)
+            w = fibonacci_word(lat, gen)
+            for i in 1:(length(w) - 1)
+                θ = phason_orbit_at(lat, i - 1)
+                expected = w[i] == 0 ? :L : :S
+                @test phason_bond_type(lat, θ) === expected
+            end
+        end
+
+        # Partition consistency: phason_bond_type and J_fourier_coeffs
+        # must operate on the same indicator. JL=1, JS=0 ⇒ J(θ) = 1 iff
+        # phason_bond_type(θ) === :L. Test on a dense grid (skip near
+        # the discontinuities to avoid Gibbs ringing).
+        K_J = 80
+        Ĵ_LS = J_fourier_coeffs(lat, 1.0, 0.0, K_J)
+        function J_recon(θ::Real)
+            s = 0.0 + 0.0im
+            for (idx, k) in enumerate((-K_J):K_J)
+                s += Ĵ_LS[idx] * cis(2π * k * θ)
+            end
+            return real(s)
+        end
+        gap = 0.05
+        θs = vcat(
+            (0.0 + gap):0.01:((1.0 - α) - gap),
+            ((1.0 - α) + gap):0.01:((2.0 - 2α) - gap),
+            ((2.0 - 2α) + gap):0.01:(1.0 - gap),
+        )
+        for θ in θs
+            indicator = phason_bond_type(lat, θ) === :L ? 1.0 : 0.0
+            @test abs(J_recon(θ) - indicator) < 0.05
+        end
+
+        # Custom α override: rational slope α = 0.25.
+        # Rule: bond = :L iff mod(θ + 0.25, 1) ≥ 0.75, equivalently θ ∈ [0.5, 0.75).
+        @test phason_bond_type(lat, 0.1; α=0.25) === :S
+        @test phason_bond_type(lat, 0.6; α=0.25) === :L
+        @test phason_bond_type(lat, 0.8; α=0.25) === :S
+    end
+
     @testset "bond_couplings" begin
         # explicit gen 4 word = [0,1,0,0,1,0,1,0]; 7 bonds
         bs = bond_couplings(lat, 1.0, 0.5; gen=4)


### PR DESCRIPTION
## Summary

Adds the bond tile-type classifier on the unit phason torus:

```julia
phason_bond_type(::FibonacciLattice, θ::Real; α=PHASON_INTERCEPT_FIBONACCI) -> Symbol
```

Returns `:L` or `:S` using **Rule B**:

```
{θ + α} ≥ 1 − α  ⇔  :L
```

equivalently `θ ∈ [0, 1-α) ∪ [2-2α, 1)`. The partition coincides with the L/S windows already used by `J_fourier_coeffs` / `_J_fourier_intervals`, so the new classifier and the existing Fourier expansion operate on the same indicator function `J(θ)`.

## Tests

Three invariants:
- Along the phason orbit `{iα}` the classifier reproduces `fibonacci_word` entry-for-entry for several generations (`0 = :L, 1 = :S`).
- On a dense θ grid the `:L` indicator agrees with a partial-sum reconstruction of `J_fourier_coeffs` at `JL=1, JS=0` (Gibbs-free zones).
- Rational-α override yields the closed-form L window.

Full suite: 22990/22990 pass.

## Refactor context

First migration PR of the FibVUMPS-side refactor (sotashimozono/FibVUMPS.jl#191). Geometry layer goes here; FibVUMPS-local `phason_bond_type` in `FibonacciFractal/tfim_mpo.jl` will be removed in a follow-up FibVUMPS PR that delegates to this function.

Version: 0.5.12 → 0.5.13